### PR TITLE
Reformat code files using clang-format and fix typos reported by codespell 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v1.16.0
+  hooks:
+  - id: codespell
+
+- repo: https://github.com/pocc/pre-commit-hooks
+  rev: v1.1.1
+  hooks:
+  - id: clang-format
+    args: [-i, --style=Google]
+#  - id: clang-tidy
+#    args: [-checks=clang-diagnostic-return-type]
+#  - id: uncrustify
+#  - id: cppcheck
+#    args: [--enable=all]

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,3 @@
 PROJECT_NAME := snapclient
 
 include $(IDF_PATH)/make/project.mk
-

--- a/README.md
+++ b/README.md
@@ -1,121 +1,162 @@
-# Snapcast client for ESP32 
+# Snapcast client for ESP32
 
 ### Synchronous Multiroom audio streaming client for [Snapcast](https://github.com/badaix/snapcast) ported to ESP32
 
-## Feature list 
+## Feature list
 - Opus and PCM decoding currently supported
-- Wifi setup from menuconfig 
-- Auto connect to snapcast server on network  
-- Buffers up to 150 ms on Wroom modules 
-- Buffers more then enough on Wrover modules 
+- Wifi setup from menuconfig
+- Auto connect to snapcast server on network
+- Buffers up to 150 ms on Wroom modules
+- Buffers more then enough on Wrover modules
 - Multiroom sync delay controlled from Snapcast server 400ms - 2000ms
 
-## Description 
-I have continued the work from @badaix and @bridadan towards a ESP32 Snapcast client. Currently it support basic features like multirum sync, network controlled volume and mute. For now it only support Opus and PCM 16bit/48Khz audio streams and the synchornization part is still being worked on. 
+## Description
+I have continued the work from @badaix and @bridadan towards a ESP32 Snapcast
+client. Currently it support basic features like multirum sync, network
+controlled volume and mute. For now it only support Opus and PCM 16bit/48Khz
+audio streams and the synchornization part is still being worked on.
 
 Please check out the task list and feel free to fill in.
 
-I have used the Infineon MA12070P Multi level Class D combined coded/amp due to its superior power effecienty on a high supply rail. It allows battery power system with good playback time at normal listen level and stil have the power to start the party.
+I have used the Infineon MA12070P Multi level Class D combined coded/amp due to
+its superior power effecienty on a high supply rail. It allows battery power
+system with good playback time at normal listen level and still have the power
+to start the party.
 
 ### Codebase
 
-The codebase is split into components and build on vanilla ESP-IDF. I stil have some refactoring on the todo list as the concept has started to settle and allow for new features can be added in a stuctured manner. In the code you will find parts that are only partly related features and still not on the task list. 
-Components 
- - MerusAudio       : Low level communication interface MA12070P 
- - opus             : Opus audio coder/decoder full submodule   
- - rtprx            : Alternative RTP audio client UDP low latency also opus based
- - lightsnapcast    : Port of @bridadan scapcast packages decode library
- - libbuffer        : Generic buffer abstraction
- - esp-dsp          : Submodule to the ESP-ADF done by David Douard
- - dsp_processor    : Audio Processor and I2S low level interface including sync buffer
+The codebase is split into components and build on vanilla ESP-IDF. I still
+have some refactoring on the todo list as the concept has started to settle and
+allow for new features can be added in a structured manner. In the code you
+will find parts that are only partly related features and still not on the task
+list.
 
-The snapclient functionanlity are implented in a task inclued in main - but will be refactored to a component in near future. 
+Components
+ - MerusAudio : Low level communication interface MA12070P
+ - opus : Opus audio coder/decoder full submodule
+ - rtprx : Alternative RTP audio client UDP low latency also opus based
+ - lightsnapcast : Port of @bridadan scapcast packages decode library
+ - libbuffer : Generic buffer abstraction
+ - esp-dsp : Submodule to the ESP-ADF done by David Douard
+ - dsp_processor : Audio Processor and I2S low level interface including sync
+   buffer
 
-Sync concept has been changed start 2021 on this implementaion and differ a bit from the way orginal snap clints handle this.
+The snapclient functionanlity are implemented in a task included in main - but
+will be refactored to a component in near future.
 
-The snapclient frontend handles communiction with the server and after succefuly hello hand shake it dispatches packages from the server. 
- - CODEC_HEADER     : Setup client audio codec (FLAC, OPUS, OGG or PCM) bitrate, n channels and bits pr sample
- - WIRE_CHUNK       : Coded audio data  
- - SERVER_SETTING   : Channel volume, mute state, playback delay etc 
- - TIME             : Ping pong time keeping packages to keep track of time dif from server to client  
+Sync concept has been changed start 2021 on this implementation and differ a
+bit from the way original snap clints handle this.
 
-Each wire_chunk of audio data comes with a timestamp and client has agreed play that sample playback-delay after the timestamp. 
-One way to handle that is to pass on audio data to a buffer with a length that compensate for for playback-delay, network jitter and DAC to speaker.
+The snapclient frontend handles communiction with the server and after
+successfully hello hand shake it dispatches packages from the server.
 
-In this implementation I have seperate the sync task to a backend on the other end of a large ring buffer. 
-Now the front end just need to pass on the audio data to the ring buffer with the server timestamp and chunk size. 
-The backen read timestamps and waits until the audio chunk has the correct playback-delay to be written to the DAC amplifer speaker pipeline.
-When the backend pipeline is in sync, any offset get rolled in by micro tuning the APLL on the ESP. No sample manipulation needed. 
-     
+ - CODEC_HEADER : Setup client audio codec (FLAC, OPUS, OGG or PCM) bitrate, n
+   channels and bits pr sample
+ - WIRE_CHUNK : Coded audio data
+ - SERVER_SETTING : Channel volume, mute state, playback delay etc
+ - TIME : Ping pong time keeping packages to keep track of time dif from server
+   to client
 
-### Hardware 
-    -   ESP pinout                         MA12070P 
+Each wire_chunk of audio data comes with a timestamp and client has agreed play
+that sample playback-delay after the timestamp. One way to handle that is to
+pass on audio data to a buffer with a length that compensate for for
+playback-delay, network jitter and DAC to speaker.
+
+In this implementation I have separated the sync task to a backend on the other
+end of a large ring buffer. Now the front end just need to pass on the audio
+data to the ring buffer with the server timestamp and chunk size. The backen
+read timestamps and waits until the audio chunk has the correct playback-delay
+to be written to the DAC amplifer speaker pipeline. When the backend pipeline
+is in sync, any offset get rolled in by micro tuning the APLL on the ESP. No
+sample manipulation needed.
+
+
+### Hardware
+    -   ESP pinout                         MA12070P
     ------------------------------------------------------
-                              ->            I2S_BCK        Audio Clock 3.072 MHz    
-                              ->            I2S_WS         Frame Word Select or L/R 
-                              ->            GND            Ground       
-                              ->            I2S_DI         Audio data 24bits LSB first 
+                              ->            I2S_BCK        Audio Clock 3.072 MHz
+                              ->            I2S_WS         Frame Word Select or L/R
+                              ->            GND            Ground
+                              ->            I2S_DI         Audio data 24bits LSB first
                               ->            MCLK           Master clk connect to I2S_BCK
                               ->            I2C_SCL        I2C clock
                               ->            I2C_SDA        I2C Data
                               ->            GND            Ground
-                              ->            NENABLE        Amplifier Enable active low                         
+                              ->            NENABLE        Amplifier Enable active low
                               ->            NMUTE          Amplifier Mute active low
-                              
-                               
-## Build 
 
-Clone this repo: 
 
-    git clone https://github.com/jorgenkraghjakobsen/snapclint 
+## Build
 
-Update third party code (opus and esp-dsp): 
+Clone this repo:
 
-    git submodule update --init 
+    git clone https://github.com/jorgenkraghjakobsen/snapclint
 
-Configure to match your setup  
+Update third party code (opus and esp-dsp):
+
+    git submodule update --init
+
+Configure to match your setup
   - Wifi network name and password
   - Audio coded setup
 
-    idf.py menuconfig 
+    idf.py menuconfig
 
 Build, compile and flash:
 
-    idf.py build flash monitor 
+    idf.py build flash monitor
 
-## Test 
-Setup a snapcast server on your network 
+## Test
+Setup a snapcast server on your network
 
-On a linux box: 
+On a linux box:
 
 Clone snapcast build and start the server
 
-    ./snapserver  
+    ./snapserver
 
-Pipe some audio to the snapcast server fifo 
+Pipe some audio to the snapcast server fifo
 
     mplayer http://ice1.somafm.com/secretagent-128-aac -ao pcm:file=/tmp/snapfifo -af format=s16LE -srate 48000
 
-Test the server config on other knowen platform 
+Test the server config on other knowen platform
 
     ./snapclient  from the snapcast repo
 
-Android : snapclient from the app play store 
+Android : snapclient from the app play store
+
+## Contribute
+
+You are very welcome to help and provide [Pull
+Requests](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+to the project.
+
+We strongly suggest you activate [pre-commit](https://pre-commit.com) hooks in
+this git repository before starting to hack and make commits.
+
+Assuming you have `pre-commit` installed on your machine (using `pip install
+pre-commit` or, on a debian-like system, `sudo apt install pre-commit`), type:
+
+```
+:~/snapclient$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+
+Then on every `git commit`, a few sanity/formatting checks will be performed.
 
 
 ## Task list
-- [ok] Fix to alinge with above 
+- [ok] Fix to alinge with above
  * kconfig
- * add codec description 
-- [ ] Integrate ESP wifi provision 
+ * add codec description
+- [ ] Integrate ESP wifi provision
 - [ok] Find and connect to Avahi broadcasted Snapcast server name
-- [ ] Add a client command interface layer like volume/mute control 
-- [ ] Build a ESP-ADF branch  
+- [ ] Add a client command interface layer like volume/mute control
+- [ ] Build a ESP-ADF branch
 
-## Minor task 
-- [ ] Propergate mute/unute from server message to DSP backend mute control. 
-  - [ ] soft mute - play sample in buffer with decresing volume 
-  - [ok] hard mute - pass on zero at the DSP hackend    
-- [ ] Startup: do not start parsing on samples to codec before sample ring buffer hits requested buffer size. 
+## Minor task
+- [ ] Propergate mute/unute from server message to DSP backend mute control.
+  - [ ] soft mute - play sample in buffer with decreasing volume
+  - [ok] hard mute - pass on zero at the DSP hackend
+- [ ] Startup: do not start parsing on samples to codec before sample ring buffer hits requested buffer size.
   - [ok] Start from empty buffer
-  

--- a/components/custom_board/Kconfig.projbuild
+++ b/components/custom_board/Kconfig.projbuild
@@ -12,10 +12,10 @@ menu "Custom Audio Board"
 
         config DAC_MA120
             bool "Infineon MA120 ClassD AMP"
-        
+
         config DAC_MA120X0
             bool "Infineon MA120X0 ClassD AMP"
-            
+
 
     endchoice
 
@@ -105,7 +105,7 @@ menu "Custom Audio Board"
              help
                  GPIO number low if clip observed
      endmenu
-     
+
      menu "Merus MA120 interface Configuration"
 		 depends on DAC_MA120
 

--- a/components/custom_board/generic_board/board.c
+++ b/components/custom_board/generic_board/board.c
@@ -3,110 +3,106 @@
  *
  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
-#include "esp_log.h"
 #include "board.h"
-#include "audio_mem.h"
 
-#include "periph_sdcard.h"
+#include "audio_mem.h"
+#include "esp_log.h"
 #include "periph_adc_button.h"
+#include "periph_sdcard.h"
 
 #if CONFIG_DAC_PCM51XX
 extern audio_hal_func_t AUDIO_CODEC_PCM51XX_DEFAULT_HANDLE;
-#define AUDIO_CODEC_DEFAULT_HANDLE  AUDIO_CODEC_PCM51XX_DEFAULT_HANDLE
+#define AUDIO_CODEC_DEFAULT_HANDLE AUDIO_CODEC_PCM51XX_DEFAULT_HANDLE
 #elif CONFIG_DAC_MA120X0
 extern audio_hal_func_t AUDIO_CODEC_MA120X0_DEFAULT_HANDLE;
-#define AUDIO_CODEC_DEFAULT_HANDLE  AUDIO_CODEC_MA120X0_DEFAULT_HANDLE
+#define AUDIO_CODEC_DEFAULT_HANDLE AUDIO_CODEC_MA120X0_DEFAULT_HANDLE
 #elif CONFIG_DAC_MA120
 extern audio_hal_func_t AUDIO_CODEC_MA120_DEFAULT_HANDLE;
-#define AUDIO_CODEC_DEFAULT_HANDLE  AUDIO_CODEC_MA120_DEFAULT_HANDLE
+#define AUDIO_CODEC_DEFAULT_HANDLE AUDIO_CODEC_MA120_DEFAULT_HANDLE
 #endif
 
 static const char *TAG = "AUDIO_BOARD";
 
 static audio_board_handle_t board_handle = 0;
 
-audio_board_handle_t audio_board_init(void)
-{
-    if (board_handle) {
-        ESP_LOGW(TAG, "The board has already been initialized!");
-        return board_handle;
-    }
-    board_handle = (audio_board_handle_t) audio_calloc(1, sizeof(struct audio_board_handle));
-    AUDIO_MEM_CHECK(TAG, board_handle, return NULL);
-    board_handle->audio_hal = audio_board_codec_init();
-
+audio_board_handle_t audio_board_init(void) {
+  if (board_handle) {
+    ESP_LOGW(TAG, "The board has already been initialized!");
     return board_handle;
+  }
+  board_handle =
+      (audio_board_handle_t)audio_calloc(1, sizeof(struct audio_board_handle));
+  AUDIO_MEM_CHECK(TAG, board_handle, return NULL);
+  board_handle->audio_hal = audio_board_codec_init();
+
+  return board_handle;
 }
 
-audio_hal_handle_t audio_board_codec_init(void)
-{
-    audio_hal_codec_config_t audio_codec_cfg = AUDIO_CODEC_DEFAULT_CONFIG();
-    audio_hal_handle_t codec_hal = audio_hal_init(
-		&audio_codec_cfg, &AUDIO_CODEC_DEFAULT_HANDLE);
-    AUDIO_NULL_CHECK(TAG, codec_hal, return NULL);
-    return codec_hal;
+audio_hal_handle_t audio_board_codec_init(void) {
+  audio_hal_codec_config_t audio_codec_cfg = AUDIO_CODEC_DEFAULT_CONFIG();
+  audio_hal_handle_t codec_hal =
+      audio_hal_init(&audio_codec_cfg, &AUDIO_CODEC_DEFAULT_HANDLE);
+  AUDIO_NULL_CHECK(TAG, codec_hal, return NULL);
+  return codec_hal;
 }
 
-esp_err_t audio_board_key_init(esp_periph_set_handle_t set)
-{
-    esp_err_t ret = ESP_OK;
-    periph_adc_button_cfg_t adc_btn_cfg = PERIPH_ADC_BUTTON_DEFAULT_CONFIG();
-    adc_arr_t adc_btn_tag = ADC_DEFAULT_ARR();
-    adc_btn_tag.adc_ch = ADC1_CHANNEL_0; // GPIO36
-    adc_btn_tag.total_steps = 4;
-    int btn_array[5] = {200, 1355, 1820, 2280, 2930};
-    adc_btn_tag.adc_level_step = btn_array;
-    adc_btn_cfg.arr = &adc_btn_tag;
-    adc_btn_cfg.arr_size = 1;
-    esp_periph_handle_t adc_btn_handle = periph_adc_button_init(&adc_btn_cfg);
-    AUDIO_NULL_CHECK(TAG, adc_btn_handle, return ESP_ERR_ADF_MEMORY_LACK);
-    ret = esp_periph_start(set, adc_btn_handle);
-    return ret;
+esp_err_t audio_board_key_init(esp_periph_set_handle_t set) {
+  esp_err_t ret = ESP_OK;
+  periph_adc_button_cfg_t adc_btn_cfg = PERIPH_ADC_BUTTON_DEFAULT_CONFIG();
+  adc_arr_t adc_btn_tag = ADC_DEFAULT_ARR();
+  adc_btn_tag.adc_ch = ADC1_CHANNEL_0;  // GPIO36
+  adc_btn_tag.total_steps = 4;
+  int btn_array[5] = {200, 1355, 1820, 2280, 2930};
+  adc_btn_tag.adc_level_step = btn_array;
+  adc_btn_cfg.arr = &adc_btn_tag;
+  adc_btn_cfg.arr_size = 1;
+  esp_periph_handle_t adc_btn_handle = periph_adc_button_init(&adc_btn_cfg);
+  AUDIO_NULL_CHECK(TAG, adc_btn_handle, return ESP_ERR_ADF_MEMORY_LACK);
+  ret = esp_periph_start(set, adc_btn_handle);
+  return ret;
 }
 
-esp_err_t audio_board_sdcard_init(esp_periph_set_handle_t set, periph_sdcard_mode_t mode)
-{
-    periph_sdcard_cfg_t sdcard_cfg = {
-        .root = "/sdcard",
-        .card_detect_pin = get_sdcard_intr_gpio(), // GPIO_NUM_34
-    };
-    esp_periph_handle_t sdcard_handle = periph_sdcard_init(&sdcard_cfg);
-    esp_err_t ret = esp_periph_start(set, sdcard_handle);
-    while (!periph_sdcard_is_mounted(sdcard_handle)) {
-        vTaskDelay(500 / portTICK_PERIOD_MS);
-    }
-    return ret;
+esp_err_t audio_board_sdcard_init(esp_periph_set_handle_t set,
+                                  periph_sdcard_mode_t mode) {
+  periph_sdcard_cfg_t sdcard_cfg = {
+      .root = "/sdcard",
+      .card_detect_pin = get_sdcard_intr_gpio(),  // GPIO_NUM_34
+  };
+  esp_periph_handle_t sdcard_handle = periph_sdcard_init(&sdcard_cfg);
+  esp_err_t ret = esp_periph_start(set, sdcard_handle);
+  while (!periph_sdcard_is_mounted(sdcard_handle)) {
+    vTaskDelay(500 / portTICK_PERIOD_MS);
+  }
+  return ret;
 }
 
-audio_board_handle_t audio_board_get_handle(void)
-{
-    return board_handle;
-}
+audio_board_handle_t audio_board_get_handle(void) { return board_handle; }
 
-esp_err_t audio_board_deinit(audio_board_handle_t audio_board)
-{
-    esp_err_t ret = ESP_OK;
-    ret |= audio_hal_deinit(audio_board->audio_hal);
-    free(audio_board);
-    board_handle = NULL;
-    return ret;
+esp_err_t audio_board_deinit(audio_board_handle_t audio_board) {
+  esp_err_t ret = ESP_OK;
+  ret |= audio_hal_deinit(audio_board->audio_hal);
+  free(audio_board);
+  board_handle = NULL;
+  return ret;
 }

--- a/components/custom_board/generic_board/board_pins_config.c
+++ b/components/custom_board/generic_board/board_pins_config.c
@@ -3,137 +3,124 @@
  *
  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
-#include "esp_log.h"
-#include "driver/gpio.h"
 #include <string.h>
-#include "board.h"
+
 #include "audio_error.h"
 #include "audio_mem.h"
+#include "board.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
 
 static const char *TAG = "GENERIC_BOARD";
 
-esp_err_t get_i2c_pins(i2c_port_t port, i2c_config_t *i2c_config)
-{
-    AUDIO_NULL_CHECK(TAG, i2c_config, return ESP_FAIL);
-    if (port == I2C_NUM_0 || port == I2C_NUM_1) {
-        i2c_config->sda_io_num = CONFIG_DAC_I2C_SDA;
-        i2c_config->scl_io_num = CONFIG_DAC_I2C_SCL;
+esp_err_t get_i2c_pins(i2c_port_t port, i2c_config_t *i2c_config) {
+  AUDIO_NULL_CHECK(TAG, i2c_config, return ESP_FAIL);
+  if (port == I2C_NUM_0 || port == I2C_NUM_1) {
+    i2c_config->sda_io_num = CONFIG_DAC_I2C_SDA;
+    i2c_config->scl_io_num = CONFIG_DAC_I2C_SCL;
+  } else {
+    i2c_config->sda_io_num = -1;
+    i2c_config->scl_io_num = -1;
+    ESP_LOGE(TAG, "i2c port %d is not supported", port);
+    return ESP_FAIL;
+  }
+  return ESP_OK;
+}
+
+esp_err_t get_i2s_pins(i2s_port_t port, i2s_pin_config_t *i2s_config) {
+  AUDIO_NULL_CHECK(TAG, i2s_config, return ESP_FAIL);
+  if (port == I2S_NUM_0) {
+    i2s_config->bck_io_num = CONFIG_MASTER_I2S_BCK_PIN;
+    i2s_config->ws_io_num = CONFIG_MASTER_I2S_LRCK_PIN;
+    i2s_config->data_out_num = CONFIG_MASTER_I2S_DATAOUT_PIN;
+    i2s_config->data_in_num = -1;
+  } else if (port == I2S_NUM_1) {
+    i2s_config->bck_io_num = CONFIG_SLAVE_I2S_BCK_PIN;
+    i2s_config->ws_io_num = CONFIG_SLAVE_I2S_LRCK_PIN;
+    i2s_config->data_out_num = CONFIG_SLAVE_I2S_DATAOUT_PIN;
+    i2s_config->data_in_num = -1;
+  } else {
+    memset(i2s_config, -1, sizeof(i2s_pin_config_t));
+    ESP_LOGE(TAG, "i2s port %d is not supported", port);
+    return ESP_FAIL;
+  }
+
+  return ESP_OK;
+}
+
+esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num) {
+  if (i2s_num >= I2S_NUM_MAX) {
+    ESP_LOGE(TAG, "Does not support i2s number(%d)", i2s_num);
+    return ESP_ERR_INVALID_ARG;
+  }
+  if (gpio_num != GPIO_NUM_0 && gpio_num != GPIO_NUM_1 &&
+      gpio_num != GPIO_NUM_3) {
+    ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", gpio_num);
+    return ESP_ERR_INVALID_ARG;
+  }
+  ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, gpio_num);
+  if (i2s_num == I2S_NUM_0) {
+    if (gpio_num == GPIO_NUM_0) {
+      PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+      WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
+    } else if (gpio_num == GPIO_NUM_1) {
+      PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
+      WRITE_PERI_REG(PIN_CTRL, 0xF0F0);
     } else {
-        i2c_config->sda_io_num = -1;
-        i2c_config->scl_io_num = -1;
-        ESP_LOGE(TAG, "i2c port %d is not supported", port);
-        return ESP_FAIL;
+      PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0RXD_U, FUNC_U0RXD_CLK_OUT2);
+      WRITE_PERI_REG(PIN_CTRL, 0xFF00);
     }
-    return ESP_OK;
+  }
+  return ESP_OK;
 }
 
-esp_err_t get_i2s_pins(i2s_port_t port, i2s_pin_config_t *i2s_config)
-{
-    AUDIO_NULL_CHECK(TAG, i2s_config, return ESP_FAIL);
-    if (port == I2S_NUM_0) {
-        i2s_config->bck_io_num = CONFIG_MASTER_I2S_BCK_PIN;
-        i2s_config->ws_io_num = CONFIG_MASTER_I2S_LRCK_PIN;
-        i2s_config->data_out_num = CONFIG_MASTER_I2S_DATAOUT_PIN;
-		i2s_config->data_in_num = -1;
-    } else if (port == I2S_NUM_1) {
-        i2s_config->bck_io_num = CONFIG_SLAVE_I2S_BCK_PIN;
-        i2s_config->ws_io_num = CONFIG_SLAVE_I2S_LRCK_PIN;
-        i2s_config->data_out_num = CONFIG_SLAVE_I2S_DATAOUT_PIN;
-		i2s_config->data_in_num = -1;
-    } else {
-        memset(i2s_config, -1, sizeof(i2s_pin_config_t));
-        ESP_LOGE(TAG, "i2s port %d is not supported", port);
-        return ESP_FAIL;
-    }
+esp_err_t get_spi_pins(
+    spi_bus_config_t *spi_config,
+    spi_device_interface_config_t *spi_device_interface_config) {
+  AUDIO_NULL_CHECK(TAG, spi_config, return ESP_FAIL);
+  AUDIO_NULL_CHECK(TAG, spi_device_interface_config, return ESP_FAIL);
 
-    return ESP_OK;
-}
+  spi_config->mosi_io_num = -1;
+  spi_config->miso_io_num = -1;
+  spi_config->sclk_io_num = -1;
+  spi_config->quadwp_io_num = -1;
+  spi_config->quadhd_io_num = -1;
 
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
-{
-    if (i2s_num >= I2S_NUM_MAX) {
-        ESP_LOGE(TAG, "Does not support i2s number(%d)", i2s_num);
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (gpio_num != GPIO_NUM_0 && gpio_num != GPIO_NUM_1 && gpio_num != GPIO_NUM_3) {
-        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", gpio_num);
-        return ESP_ERR_INVALID_ARG;
-    }
-    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, gpio_num);
-    if (i2s_num == I2S_NUM_0) {
-        if (gpio_num == GPIO_NUM_0) {
-            PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
-            WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
-        } else if (gpio_num == GPIO_NUM_1) {
-            PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
-            WRITE_PERI_REG(PIN_CTRL, 0xF0F0);
-        } else {
-            PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0RXD_U, FUNC_U0RXD_CLK_OUT2);
-            WRITE_PERI_REG(PIN_CTRL, 0xFF00);
-        }
-    }
-    return ESP_OK;
-}
+  spi_device_interface_config->spics_io_num = -1;
 
-esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config_t *spi_device_interface_config)
-{
-    AUDIO_NULL_CHECK(TAG, spi_config, return ESP_FAIL);
-    AUDIO_NULL_CHECK(TAG, spi_device_interface_config, return ESP_FAIL);
-
-    spi_config->mosi_io_num = -1;
-    spi_config->miso_io_num = -1;
-    spi_config->sclk_io_num = -1;
-    spi_config->quadwp_io_num = -1;
-    spi_config->quadhd_io_num = -1;
-
-    spi_device_interface_config->spics_io_num = -1;
-
-    ESP_LOGW(TAG, "SPI interface is not supported");
-    return ESP_OK;
+  ESP_LOGW(TAG, "SPI interface is not supported");
+  return ESP_OK;
 }
 
 // sdcard
 
-int8_t get_sdcard_intr_gpio(void)
-{
-    return SDCARD_INTR_GPIO;
-}
+int8_t get_sdcard_intr_gpio(void) { return SDCARD_INTR_GPIO; }
 
-int8_t get_sdcard_open_file_num_max(void)
-{
-    return SDCARD_OPEN_FILE_NUM_MAX;
-}
+int8_t get_sdcard_open_file_num_max(void) { return SDCARD_OPEN_FILE_NUM_MAX; }
 
-int8_t get_input_volup_id(void)
-{
-    return BUTTON_VOLUP_ID;
-}
+int8_t get_input_volup_id(void) { return BUTTON_VOLUP_ID; }
 
-int8_t get_input_voldown_id(void)
-{
-    return BUTTON_VOLDOWN_ID;
-}
+int8_t get_input_voldown_id(void) { return BUTTON_VOLDOWN_ID; }
 
-int8_t get_pa_enable_gpio(void)
-{
-    return PA_ENABLE_GPIO;
-}
+int8_t get_pa_enable_gpio(void) { return PA_ENABLE_GPIO; }

--- a/components/custom_board/generic_board/include/board.h
+++ b/components/custom_board/generic_board/include/board.h
@@ -3,22 +3,24 @@
  *
  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
@@ -39,8 +41,8 @@ extern "C" {
  * @brief Audio board handle
  */
 struct audio_board_handle {
-    audio_hal_handle_t audio_hal;    /*!< pa hardware abstract layer handle */
-    audio_hal_handle_t adc_hal;      /*!< adc hardware abstract layer handle */
+  audio_hal_handle_t audio_hal; /*!< pa hardware abstract layer handle */
+  audio_hal_handle_t adc_hal;   /*!< adc hardware abstract layer handle */
 };
 
 typedef struct audio_board_handle *audio_board_handle_t;
@@ -86,7 +88,8 @@ esp_err_t audio_board_key_init(esp_periph_set_handle_t set);
  *     - ESP_OK, success
  *     - Others, fail
  */
-esp_err_t audio_board_sdcard_init(esp_periph_set_handle_t set, periph_sdcard_mode_t mode);
+esp_err_t audio_board_sdcard_init(esp_periph_set_handle_t set,
+                                  periph_sdcard_mode_t mode);
 
 /**
  * @brief Query audio_board_handle

--- a/components/custom_board/generic_board/include/board_def.h
+++ b/components/custom_board/generic_board/include/board_def.h
@@ -3,75 +3,80 @@
  *
  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
 #ifndef _AUDIO_BOARD_DEFINITION_H_
 #define _AUDIO_BOARD_DEFINITION_H_
 
-#define BUTTON_VOLUP_ID           0
-#define BUTTON_VOLDOWN_ID         1
-#define BUTTON_MUTE_ID            2
-#define BUTTON_SET_ID             3
+#define BUTTON_VOLUP_ID 0
+#define BUTTON_VOLDOWN_ID 1
+#define BUTTON_MUTE_ID 2
+#define BUTTON_SET_ID 3
 
-#define PA_ENABLE_GPIO            GPIO_NUM_12
-#define ADC_DETECT_GPIO           GPIO_NUM_36
-#define BATTERY_DETECT_GPIO       GPIO_NUM_37
+#define PA_ENABLE_GPIO GPIO_NUM_12
+#define ADC_DETECT_GPIO GPIO_NUM_36
+#define BATTERY_DETECT_GPIO GPIO_NUM_37
 
-#define SDCARD_OPEN_FILE_NUM_MAX  5
-#define SDCARD_INTR_GPIO          GPIO_NUM_34
+#define SDCARD_OPEN_FILE_NUM_MAX 5
+#define SDCARD_INTR_GPIO GPIO_NUM_34
 
-#define AUDIO_CODEC_DEFAULT_CONFIG(){                   \
-        .adc_input  = AUDIO_HAL_ADC_INPUT_LINE1,        \
-        .dac_output = AUDIO_HAL_DAC_OUTPUT_ALL,         \
-        .codec_mode = AUDIO_HAL_CODEC_MODE_BOTH,        \
-        .i2s_iface = {                                  \
-            .mode = AUDIO_HAL_MODE_SLAVE,               \
-            .fmt = AUDIO_HAL_I2S_NORMAL,                \
-            .samples = AUDIO_HAL_48K_SAMPLES,           \
-            .bits = AUDIO_HAL_BIT_LENGTH_16BITS,        \
-        },                                              \
-};
+#define AUDIO_CODEC_DEFAULT_CONFIG()               \
+  {                                                \
+      .adc_input = AUDIO_HAL_ADC_INPUT_LINE1,      \
+      .dac_output = AUDIO_HAL_DAC_OUTPUT_ALL,      \
+      .codec_mode = AUDIO_HAL_CODEC_MODE_BOTH,     \
+      .i2s_iface =                                 \
+          {                                        \
+              .mode = AUDIO_HAL_MODE_SLAVE,        \
+              .fmt = AUDIO_HAL_I2S_NORMAL,         \
+              .samples = AUDIO_HAL_48K_SAMPLES,    \
+              .bits = AUDIO_HAL_BIT_LENGTH_16BITS, \
+          },                                       \
+  };
 
-#define INPUT_KEY_NUM     4
+#define INPUT_KEY_NUM 4
 
-#define INPUT_KEY_DEFAULT_INFO() {                      \
-    {                                                   \
-        .type = PERIPH_ID_ADC_BTN,                      \
-        .user_id = INPUT_KEY_USER_ID_VOLUP,             \
-        .act_id = BUTTON_VOLUP_ID,                      \
-    },                                                  \
-    {                                                   \
-        .type = PERIPH_ID_ADC_BTN,                      \
-        .user_id = INPUT_KEY_USER_ID_VOLDOWN,           \
-        .act_id = BUTTON_VOLDOWN_ID,                    \
-    },                                                  \
-    {                                                   \
-        .type = PERIPH_ID_ADC_BTN,                      \
-        .user_id = INPUT_KEY_USER_ID_MUTE,              \
-        .act_id = BUTTON_MUTE_ID,                       \
-    },                                                  \
-    {                                                   \
-        .type = PERIPH_ID_ADC_BTN,                      \
-        .user_id = INPUT_KEY_USER_ID_SET,               \
-        .act_id = BUTTON_SET_ID,                        \
-    },                                                  \
-}
+#define INPUT_KEY_DEFAULT_INFO()                  \
+  {                                               \
+    {                                             \
+        .type = PERIPH_ID_ADC_BTN,                \
+        .user_id = INPUT_KEY_USER_ID_VOLUP,       \
+        .act_id = BUTTON_VOLUP_ID,                \
+    },                                            \
+        {                                         \
+            .type = PERIPH_ID_ADC_BTN,            \
+            .user_id = INPUT_KEY_USER_ID_VOLDOWN, \
+            .act_id = BUTTON_VOLDOWN_ID,          \
+        },                                        \
+        {                                         \
+            .type = PERIPH_ID_ADC_BTN,            \
+            .user_id = INPUT_KEY_USER_ID_MUTE,    \
+            .act_id = BUTTON_MUTE_ID,             \
+        },                                        \
+        {                                         \
+            .type = PERIPH_ID_ADC_BTN,            \
+            .user_id = INPUT_KEY_USER_ID_SET,     \
+            .act_id = BUTTON_SET_ID,              \
+        },                                        \
+  }
 
 #endif

--- a/components/custom_board/ma120/include/MerusAudio.h
+++ b/components/custom_board/ma120/include/MerusAudio.h
@@ -1,13 +1,13 @@
-#ifndef _MERUSAUDIO_H_ 
+#ifndef _MERUSAUDIO_H_
 #define _MERUSAUDIO_H_
 
-esp_err_t ma120_init(audio_hal_codec_config_t *codec_cfg);  
+esp_err_t ma120_init(audio_hal_codec_config_t *codec_cfg);
 esp_err_t ma120_deinit(void);
 esp_err_t ma120_set_volume(int vol);
 esp_err_t ma120_get_volume(int *value);
 esp_err_t ma120_set_mute(bool enable);
 esp_err_t ma120_get_mute(bool *enabled);
-esp_err_t ma120_ctrl(audio_hal_codec_mode_t , audio_hal_ctrl_t);
+esp_err_t ma120_ctrl(audio_hal_codec_mode_t, audio_hal_ctrl_t);
 
 void setup_ma120(void);
 void ma120_read_error(uint8_t i2c_addr);
@@ -15,13 +15,13 @@ void ma120_setup_audio(uint8_t i2c_addr);
 
 void i2c_master_init(void);
 
-esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t value); 
-esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *wbuf, uint8_t n);
- 
+esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                        uint8_t value);
+esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                   uint8_t *wbuf, uint8_t n);
+
 uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address);
-esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *rbuf, uint8_t n);
+esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                  uint8_t *rbuf, uint8_t n);
 
-
-#endif /* _MERUSAUDIO_H_  */ 
-
-  
+#endif /* _MERUSAUDIO_H_  */

--- a/components/custom_board/ma120/include/ma120x0.h
+++ b/components/custom_board/ma120/include/ma120x0.h
@@ -1,1226 +1,1922 @@
 /*---------------------------------------------------------------------------------------*/
-/*   Merus Audio MA120x0 register map                                                    */
+/*   Merus Audio MA120x0 register map */
 /*                                                                                       */
-/*   Provides : Defines for registers and symbols in merus audio amplifiers              */
-/*              Macros for set and get content of symbols                                */
-/*              Read-modify-write on write to symbols less then 8 bits                   */
+/*   Provides : Defines for registers and symbols in merus audio amplifiers */
+/*              Macros for set and get content of symbols */
+/*              Read-modify-write on write to symbols less then 8 bits */
 /*                                                                                       */
-/*   Symbols is a collection of 1 to 8 bits within a single address                      */
+/*   Symbols is a collection of 1 to 8 bits within a single address */
 /*                                                                                       */
-/*   Provided as is - free to use and share                                              */
+/*   Provided as is - free to use and share */
 /*                                                                                       */
-/*   Timestamp                        :                         Thu Feb 23 23:06:51 2017 */
-/*   Created from database            :                     ma12070_register_spec_rev6_1 */
-/*   Errors and updates please contact:       Jorgen Kragh Jakobsen, jkj@merus-audio.com */
+/*   Timestamp                        :                         Thu Feb 23
+ * 23:06:51 2017 */
+/*   Created from database            : ma12070_register_spec_rev6_1 */
+/*   Errors and updates please contact:       Jorgen Kragh Jakobsen,
+ * jkj@merus-audio.com */
 /*---------------------------------------------------------------------------------------*/
 
 #include <stdint.h>
 
-
-#ifndef _MA120X0_H_ 
-#define _MA120X0_H_ 
-
+#ifndef _MA120X0_H_
+#define _MA120X0_H_
 
 //------------------------------------------------------------------------------manualPM---
-// Select Manual PowerMode control 
+// Select Manual PowerMode control
 #define MA_manualPM__a 0
 #define MA_manualPM__len 1
 #define MA_manualPM__mask 0x40
 #define MA_manualPM__shift 0x06
 #define MA_manualPM__reset 0x00
-#define set_obj_MA_manualPM(o,y) ({ uint8_t __ret = o.read(0); o.write(0,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_manualPM(y) ({ uint8_t __ret = ma_read_byte(0); ma_write_byte(0,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_manualPM(o) (o.read(0) & 0x40)>>6 
-#define get_MA_manualPM() ( ma_read_byte(0) & 0x40)>>6 
+#define set_obj_MA_manualPM(o, y)                   \
+  ({                                                \
+    uint8_t __ret = o.read(0);                      \
+    o.write(0, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_manualPM(y)                                \
+  ({                                                      \
+    uint8_t __ret = ma_read_byte(0);                      \
+    ma_write_byte(0, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_manualPM(o) (o.read(0) & 0x40) >> 6
+#define get_MA_manualPM() (ma_read_byte(0) & 0x40) >> 6
 //------------------------------------------------------------------------------PM_man---
-// Manual selected power mode 
+// Manual selected power mode
 #define MA_PM_man__a 0
 #define MA_PM_man__len 2
 #define MA_PM_man__mask 0x30
 #define MA_PM_man__shift 0x04
 #define MA_PM_man__reset 0x03
-#define set_obj_MA_PM_man(o,y) ({ uint8_t __ret = o.read(0); o.write(0,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_PM_man(y) ({ uint8_t __ret = ma_read_byte(0); ma_write_byte(0,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_PM_man(o) (o.read(0) & 0x30)>>4 
-#define get_MA_PM_man() ( ma_read_byte(0) & 0x30)>>4 
+#define set_obj_MA_PM_man(o, y)                     \
+  ({                                                \
+    uint8_t __ret = o.read(0);                      \
+    o.write(0, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_PM_man(y)                                  \
+  ({                                                      \
+    uint8_t __ret = ma_read_byte(0);                      \
+    ma_write_byte(0, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_PM_man(o) (o.read(0) & 0x30) >> 4
+#define get_MA_PM_man() (ma_read_byte(0) & 0x30) >> 4
 //------------------------------------------------------------------------------Mthr_1to2---
-// Mod. index threshold value for PM1=>PM2 change. 
+// Mod. index threshold value for PM1=>PM2 change.
 #define MA_Mthr_1to2__a 1
 #define MA_Mthr_1to2__len 8
 #define MA_Mthr_1to2__mask 0xff
 #define MA_Mthr_1to2__shift 0x00
 #define MA_Mthr_1to2__reset 0x3c
-#define set_obj_MA_Mthr_1to2(o,y) o.write(1,y);
-#define set_MA_Mthr_1to2(y) ma_write_byte(1,y);
-#define get_obj_MA_Mthr_1to2(o) (o.read(1) & 0xff)>>0 
-#define get_MA_Mthr_1to2() ( ma_read_byte(1) & 0xff)>>0 
+#define set_obj_MA_Mthr_1to2(o, y) o.write(1, y);
+#define set_MA_Mthr_1to2(y) ma_write_byte(1, y);
+#define get_obj_MA_Mthr_1to2(o) (o.read(1) & 0xff) >> 0
+#define get_MA_Mthr_1to2() (ma_read_byte(1) & 0xff) >> 0
 //------------------------------------------------------------------------------Mthr_2to1---
-// Mod. index threshold value for PM2=>PM1 change. 
+// Mod. index threshold value for PM2=>PM1 change.
 #define MA_Mthr_2to1__a 2
 #define MA_Mthr_2to1__len 8
 #define MA_Mthr_2to1__mask 0xff
 #define MA_Mthr_2to1__shift 0x00
 #define MA_Mthr_2to1__reset 0x32
-#define set_obj_MA_Mthr_2to1(o,y) o.write(2,y);
-#define set_MA_Mthr_2to1(y) ma_write_byte(2,y);
-#define get_obj_MA_Mthr_2to1(o) (o.read(2) & 0xff)>>0 
-#define get_MA_Mthr_2to1() ( ma_read_byte(2) & 0xff)>>0 
+#define set_obj_MA_Mthr_2to1(o, y) o.write(2, y);
+#define set_MA_Mthr_2to1(y) ma_write_byte(2, y);
+#define get_obj_MA_Mthr_2to1(o) (o.read(2) & 0xff) >> 0
+#define get_MA_Mthr_2to1() (ma_read_byte(2) & 0xff) >> 0
 //------------------------------------------------------------------------------Mthr_2to3---
-// Mod. index threshold value for PM2=>PM3 change. 
+// Mod. index threshold value for PM2=>PM3 change.
 #define MA_Mthr_2to3__a 3
 #define MA_Mthr_2to3__len 8
 #define MA_Mthr_2to3__mask 0xff
 #define MA_Mthr_2to3__shift 0x00
 #define MA_Mthr_2to3__reset 0x5a
-#define set_obj_MA_Mthr_2to3(o,y) o.write(3,y);
-#define set_MA_Mthr_2to3(y) ma_write_byte(3,y);
-#define get_obj_MA_Mthr_2to3(o) (o.read(3) & 0xff)>>0 
-#define get_MA_Mthr_2to3() ( ma_read_byte(3) & 0xff)>>0 
+#define set_obj_MA_Mthr_2to3(o, y) o.write(3, y);
+#define set_MA_Mthr_2to3(y) ma_write_byte(3, y);
+#define get_obj_MA_Mthr_2to3(o) (o.read(3) & 0xff) >> 0
+#define get_MA_Mthr_2to3() (ma_read_byte(3) & 0xff) >> 0
 //------------------------------------------------------------------------------Mthr_3to2---
-// Mod. index threshold value for PM3=>PM2 change. 
+// Mod. index threshold value for PM3=>PM2 change.
 #define MA_Mthr_3to2__a 4
 #define MA_Mthr_3to2__len 8
 #define MA_Mthr_3to2__mask 0xff
 #define MA_Mthr_3to2__shift 0x00
 #define MA_Mthr_3to2__reset 0x50
-#define set_obj_MA_Mthr_3to2(o,y) o.write(4,y);
-#define set_MA_Mthr_3to2(y) ma_write_byte(4,y);
-#define get_obj_MA_Mthr_3to2(o) (o.read(4) & 0xff)>>0 
-#define get_MA_Mthr_3to2() ( ma_read_byte(4) & 0xff)>>0 
+#define set_obj_MA_Mthr_3to2(o, y) o.write(4, y);
+#define set_MA_Mthr_3to2(y) ma_write_byte(4, y);
+#define get_obj_MA_Mthr_3to2(o) (o.read(4) & 0xff) >> 0
+#define get_MA_Mthr_3to2() (ma_read_byte(4) & 0xff) >> 0
 //------------------------------------------------------------------------------pwmClkDiv_nom---
-// PWM default clock divider value 
+// PWM default clock divider value
 #define MA_pwmClkDiv_nom__a 8
 #define MA_pwmClkDiv_nom__len 8
 #define MA_pwmClkDiv_nom__mask 0xff
 #define MA_pwmClkDiv_nom__shift 0x00
 #define MA_pwmClkDiv_nom__reset 0x26
-#define set_obj_MA_pwmClkDiv_nom(o,y) o.write(8,y);
-#define set_MA_pwmClkDiv_nom(y) ma_write_byte(8,y);
-#define get_obj_MA_pwmClkDiv_nom(o) (o.read(8) & 0xff)>>0 
-#define get_MA_pwmClkDiv_nom() ( ma_read_byte(8) & 0xff)>>0 
+#define set_obj_MA_pwmClkDiv_nom(o, y) o.write(8, y);
+#define set_MA_pwmClkDiv_nom(y) ma_write_byte(8, y);
+#define get_obj_MA_pwmClkDiv_nom(o) (o.read(8) & 0xff) >> 0
+#define get_MA_pwmClkDiv_nom() (ma_read_byte(8) & 0xff) >> 0
 //------------------------------------------------------------------------------ocp_latch_en---
-// High to use permanently latching level-2 OCP 
+// High to use permanently latching level-2 OCP
 #define MA_ocp_latch_en__a 10
 #define MA_ocp_latch_en__len 1
 #define MA_ocp_latch_en__mask 0x02
 #define MA_ocp_latch_en__shift 0x01
 #define MA_ocp_latch_en__reset 0x00
-#define set_obj_MA_ocp_latch_en(o,y) ({ uint8_t __ret = o.read(10); o.write(10,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_ocp_latch_en(y) ({ uint8_t __ret = ma_read_byte(10); ma_write_byte(10,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_ocp_latch_en(o) (o.read(10) & 0x02)>>1 
-#define get_MA_ocp_latch_en() ( ma_read_byte(10) & 0x02)>>1 
+#define set_obj_MA_ocp_latch_en(o, y)                \
+  ({                                                 \
+    uint8_t __ret = o.read(10);                      \
+    o.write(10, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_ocp_latch_en(y)                             \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(10);                      \
+    ma_write_byte(10, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_ocp_latch_en(o) (o.read(10) & 0x02) >> 1
+#define get_MA_ocp_latch_en() (ma_read_byte(10) & 0x02) >> 1
 //------------------------------------------------------------------------------lf_clamp_en---
-// High (default) to enable LF int2+3 clamping on clip 
+// High (default) to enable LF int2+3 clamping on clip
 #define MA_lf_clamp_en__a 10
 #define MA_lf_clamp_en__len 1
 #define MA_lf_clamp_en__mask 0x80
 #define MA_lf_clamp_en__shift 0x07
 #define MA_lf_clamp_en__reset 0x00
-#define set_obj_MA_lf_clamp_en(o,y) ({ uint8_t __ret = o.read(10); o.write(10,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_lf_clamp_en(y) ({ uint8_t __ret = ma_read_byte(10); ma_write_byte(10,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_lf_clamp_en(o) (o.read(10) & 0x80)>>7 
-#define get_MA_lf_clamp_en() ( ma_read_byte(10) & 0x80)>>7 
+#define set_obj_MA_lf_clamp_en(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(10);                      \
+    o.write(10, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_lf_clamp_en(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(10);                      \
+    ma_write_byte(10, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_lf_clamp_en(o) (o.read(10) & 0x80) >> 7
+#define get_MA_lf_clamp_en() (ma_read_byte(10) & 0x80) >> 7
 //------------------------------------------------------------------------------PMcfg_BTL_B.modType---
-//  
+//
 #define MA_PMcfg_BTL_B__modType__a 18
 #define MA_PMcfg_BTL_B__modType__len 2
 #define MA_PMcfg_BTL_B__modType__mask 0x18
 #define MA_PMcfg_BTL_B__modType__shift 0x03
 #define MA_PMcfg_BTL_B__modType__reset 0x02
-#define set_obj_MA_PMcfg_BTL_B__modType(o,y) ({ uint8_t __ret = o.read(18); o.write(18,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_BTL_B__modType(y) ({ uint8_t __ret = ma_read_byte(18); ma_write_byte(18,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_BTL_B__modType(o) (o.read(18) & 0x18)>>3 
-#define get_MA_PMcfg_BTL_B__modType() ( ma_read_byte(18) & 0x18)>>3 
+#define set_obj_MA_PMcfg_BTL_B__modType(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(18);                      \
+    o.write(18, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_BTL_B__modType(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(18);                      \
+    ma_write_byte(18, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_BTL_B__modType(o) (o.read(18) & 0x18) >> 3
+#define get_MA_PMcfg_BTL_B__modType() (ma_read_byte(18) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_BTL_B.freqDiv---
-//  
+//
 #define MA_PMcfg_BTL_B__freqDiv__a 18
 #define MA_PMcfg_BTL_B__freqDiv__len 2
 #define MA_PMcfg_BTL_B__freqDiv__mask 0x06
 #define MA_PMcfg_BTL_B__freqDiv__shift 0x01
 #define MA_PMcfg_BTL_B__freqDiv__reset 0x01
-#define set_obj_MA_PMcfg_BTL_B__freqDiv(o,y) ({ uint8_t __ret = o.read(18); o.write(18,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_BTL_B__freqDiv(y) ({ uint8_t __ret = ma_read_byte(18); ma_write_byte(18,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_BTL_B__freqDiv(o) (o.read(18) & 0x06)>>1 
-#define get_MA_PMcfg_BTL_B__freqDiv() ( ma_read_byte(18) & 0x06)>>1 
+#define set_obj_MA_PMcfg_BTL_B__freqDiv(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(18);                      \
+    o.write(18, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_BTL_B__freqDiv(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(18);                      \
+    ma_write_byte(18, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_BTL_B__freqDiv(o) (o.read(18) & 0x06) >> 1
+#define get_MA_PMcfg_BTL_B__freqDiv() (ma_read_byte(18) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_BTL_B.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_BTL_B__lf_gain_ol__a 18
 #define MA_PMcfg_BTL_B__lf_gain_ol__len 1
 #define MA_PMcfg_BTL_B__lf_gain_ol__mask 0x01
 #define MA_PMcfg_BTL_B__lf_gain_ol__shift 0x00
 #define MA_PMcfg_BTL_B__lf_gain_ol__reset 0x01
-#define set_obj_MA_PMcfg_BTL_B__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(18); o.write(18,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_BTL_B__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(18); ma_write_byte(18,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_BTL_B__lf_gain_ol(o) (o.read(18) & 0x01)>>0 
-#define get_MA_PMcfg_BTL_B__lf_gain_ol() ( ma_read_byte(18) & 0x01)>>0 
+#define set_obj_MA_PMcfg_BTL_B__lf_gain_ol(o, y)     \
+  ({                                                 \
+    uint8_t __ret = o.read(18);                      \
+    o.write(18, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_BTL_B__lf_gain_ol(y)                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(18);                      \
+    ma_write_byte(18, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_BTL_B__lf_gain_ol(o) (o.read(18) & 0x01) >> 0
+#define get_MA_PMcfg_BTL_B__lf_gain_ol() (ma_read_byte(18) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_BTL_C.freqDiv---
-//  
+//
 #define MA_PMcfg_BTL_C__freqDiv__a 19
 #define MA_PMcfg_BTL_C__freqDiv__len 2
 #define MA_PMcfg_BTL_C__freqDiv__mask 0x06
 #define MA_PMcfg_BTL_C__freqDiv__shift 0x01
 #define MA_PMcfg_BTL_C__freqDiv__reset 0x01
-#define set_obj_MA_PMcfg_BTL_C__freqDiv(o,y) ({ uint8_t __ret = o.read(19); o.write(19,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_BTL_C__freqDiv(y) ({ uint8_t __ret = ma_read_byte(19); ma_write_byte(19,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_BTL_C__freqDiv(o) (o.read(19) & 0x06)>>1 
-#define get_MA_PMcfg_BTL_C__freqDiv() ( ma_read_byte(19) & 0x06)>>1 
+#define set_obj_MA_PMcfg_BTL_C__freqDiv(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(19);                      \
+    o.write(19, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_BTL_C__freqDiv(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(19);                      \
+    ma_write_byte(19, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_BTL_C__freqDiv(o) (o.read(19) & 0x06) >> 1
+#define get_MA_PMcfg_BTL_C__freqDiv() (ma_read_byte(19) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_BTL_C.modType---
-//  
+//
 #define MA_PMcfg_BTL_C__modType__a 19
 #define MA_PMcfg_BTL_C__modType__len 2
 #define MA_PMcfg_BTL_C__modType__mask 0x18
 #define MA_PMcfg_BTL_C__modType__shift 0x03
 #define MA_PMcfg_BTL_C__modType__reset 0x01
-#define set_obj_MA_PMcfg_BTL_C__modType(o,y) ({ uint8_t __ret = o.read(19); o.write(19,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_BTL_C__modType(y) ({ uint8_t __ret = ma_read_byte(19); ma_write_byte(19,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_BTL_C__modType(o) (o.read(19) & 0x18)>>3 
-#define get_MA_PMcfg_BTL_C__modType() ( ma_read_byte(19) & 0x18)>>3 
+#define set_obj_MA_PMcfg_BTL_C__modType(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(19);                      \
+    o.write(19, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_BTL_C__modType(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(19);                      \
+    ma_write_byte(19, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_BTL_C__modType(o) (o.read(19) & 0x18) >> 3
+#define get_MA_PMcfg_BTL_C__modType() (ma_read_byte(19) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_BTL_C.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_BTL_C__lf_gain_ol__a 19
 #define MA_PMcfg_BTL_C__lf_gain_ol__len 1
 #define MA_PMcfg_BTL_C__lf_gain_ol__mask 0x01
 #define MA_PMcfg_BTL_C__lf_gain_ol__shift 0x00
 #define MA_PMcfg_BTL_C__lf_gain_ol__reset 0x00
-#define set_obj_MA_PMcfg_BTL_C__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(19); o.write(19,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_BTL_C__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(19); ma_write_byte(19,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_BTL_C__lf_gain_ol(o) (o.read(19) & 0x01)>>0 
-#define get_MA_PMcfg_BTL_C__lf_gain_ol() ( ma_read_byte(19) & 0x01)>>0 
+#define set_obj_MA_PMcfg_BTL_C__lf_gain_ol(o, y)     \
+  ({                                                 \
+    uint8_t __ret = o.read(19);                      \
+    o.write(19, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_BTL_C__lf_gain_ol(y)                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(19);                      \
+    ma_write_byte(19, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_BTL_C__lf_gain_ol(o) (o.read(19) & 0x01) >> 0
+#define get_MA_PMcfg_BTL_C__lf_gain_ol() (ma_read_byte(19) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_BTL_D.modType---
-//  
+//
 #define MA_PMcfg_BTL_D__modType__a 20
 #define MA_PMcfg_BTL_D__modType__len 2
 #define MA_PMcfg_BTL_D__modType__mask 0x18
 #define MA_PMcfg_BTL_D__modType__shift 0x03
 #define MA_PMcfg_BTL_D__modType__reset 0x02
-#define set_obj_MA_PMcfg_BTL_D__modType(o,y) ({ uint8_t __ret = o.read(20); o.write(20,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_BTL_D__modType(y) ({ uint8_t __ret = ma_read_byte(20); ma_write_byte(20,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_BTL_D__modType(o) (o.read(20) & 0x18)>>3 
-#define get_MA_PMcfg_BTL_D__modType() ( ma_read_byte(20) & 0x18)>>3 
+#define set_obj_MA_PMcfg_BTL_D__modType(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(20);                      \
+    o.write(20, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_BTL_D__modType(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(20);                      \
+    ma_write_byte(20, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_BTL_D__modType(o) (o.read(20) & 0x18) >> 3
+#define get_MA_PMcfg_BTL_D__modType() (ma_read_byte(20) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_BTL_D.freqDiv---
-//  
+//
 #define MA_PMcfg_BTL_D__freqDiv__a 20
 #define MA_PMcfg_BTL_D__freqDiv__len 2
 #define MA_PMcfg_BTL_D__freqDiv__mask 0x06
 #define MA_PMcfg_BTL_D__freqDiv__shift 0x01
 #define MA_PMcfg_BTL_D__freqDiv__reset 0x02
-#define set_obj_MA_PMcfg_BTL_D__freqDiv(o,y) ({ uint8_t __ret = o.read(20); o.write(20,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_BTL_D__freqDiv(y) ({ uint8_t __ret = ma_read_byte(20); ma_write_byte(20,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_BTL_D__freqDiv(o) (o.read(20) & 0x06)>>1 
-#define get_MA_PMcfg_BTL_D__freqDiv() ( ma_read_byte(20) & 0x06)>>1 
+#define set_obj_MA_PMcfg_BTL_D__freqDiv(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(20);                      \
+    o.write(20, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_BTL_D__freqDiv(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(20);                      \
+    ma_write_byte(20, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_BTL_D__freqDiv(o) (o.read(20) & 0x06) >> 1
+#define get_MA_PMcfg_BTL_D__freqDiv() (ma_read_byte(20) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_BTL_D.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_BTL_D__lf_gain_ol__a 20
 #define MA_PMcfg_BTL_D__lf_gain_ol__len 1
 #define MA_PMcfg_BTL_D__lf_gain_ol__mask 0x01
 #define MA_PMcfg_BTL_D__lf_gain_ol__shift 0x00
 #define MA_PMcfg_BTL_D__lf_gain_ol__reset 0x00
-#define set_obj_MA_PMcfg_BTL_D__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(20); o.write(20,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_BTL_D__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(20); ma_write_byte(20,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_BTL_D__lf_gain_ol(o) (o.read(20) & 0x01)>>0 
-#define get_MA_PMcfg_BTL_D__lf_gain_ol() ( ma_read_byte(20) & 0x01)>>0 
+#define set_obj_MA_PMcfg_BTL_D__lf_gain_ol(o, y)     \
+  ({                                                 \
+    uint8_t __ret = o.read(20);                      \
+    o.write(20, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_BTL_D__lf_gain_ol(y)                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(20);                      \
+    ma_write_byte(20, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_BTL_D__lf_gain_ol(o) (o.read(20) & 0x01) >> 0
+#define get_MA_PMcfg_BTL_D__lf_gain_ol() (ma_read_byte(20) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_SE_A.modType---
-//  
+//
 #define MA_PMcfg_SE_A__modType__a 21
 #define MA_PMcfg_SE_A__modType__len 2
 #define MA_PMcfg_SE_A__modType__mask 0x18
 #define MA_PMcfg_SE_A__modType__shift 0x03
 #define MA_PMcfg_SE_A__modType__reset 0x01
-#define set_obj_MA_PMcfg_SE_A__modType(o,y) ({ uint8_t __ret = o.read(21); o.write(21,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_SE_A__modType(y) ({ uint8_t __ret = ma_read_byte(21); ma_write_byte(21,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_SE_A__modType(o) (o.read(21) & 0x18)>>3 
-#define get_MA_PMcfg_SE_A__modType() ( ma_read_byte(21) & 0x18)>>3 
+#define set_obj_MA_PMcfg_SE_A__modType(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(21);                      \
+    o.write(21, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_SE_A__modType(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(21);                      \
+    ma_write_byte(21, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_SE_A__modType(o) (o.read(21) & 0x18) >> 3
+#define get_MA_PMcfg_SE_A__modType() (ma_read_byte(21) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_SE_A.freqDiv---
-//  
+//
 #define MA_PMcfg_SE_A__freqDiv__a 21
 #define MA_PMcfg_SE_A__freqDiv__len 2
 #define MA_PMcfg_SE_A__freqDiv__mask 0x06
 #define MA_PMcfg_SE_A__freqDiv__shift 0x01
 #define MA_PMcfg_SE_A__freqDiv__reset 0x00
-#define set_obj_MA_PMcfg_SE_A__freqDiv(o,y) ({ uint8_t __ret = o.read(21); o.write(21,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_SE_A__freqDiv(y) ({ uint8_t __ret = ma_read_byte(21); ma_write_byte(21,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_SE_A__freqDiv(o) (o.read(21) & 0x06)>>1 
-#define get_MA_PMcfg_SE_A__freqDiv() ( ma_read_byte(21) & 0x06)>>1 
+#define set_obj_MA_PMcfg_SE_A__freqDiv(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(21);                      \
+    o.write(21, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_SE_A__freqDiv(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(21);                      \
+    ma_write_byte(21, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_SE_A__freqDiv(o) (o.read(21) & 0x06) >> 1
+#define get_MA_PMcfg_SE_A__freqDiv() (ma_read_byte(21) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_SE_A.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_SE_A__lf_gain_ol__a 21
 #define MA_PMcfg_SE_A__lf_gain_ol__len 1
 #define MA_PMcfg_SE_A__lf_gain_ol__mask 0x01
 #define MA_PMcfg_SE_A__lf_gain_ol__shift 0x00
 #define MA_PMcfg_SE_A__lf_gain_ol__reset 0x01
-#define set_obj_MA_PMcfg_SE_A__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(21); o.write(21,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_SE_A__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(21); ma_write_byte(21,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_SE_A__lf_gain_ol(o) (o.read(21) & 0x01)>>0 
-#define get_MA_PMcfg_SE_A__lf_gain_ol() ( ma_read_byte(21) & 0x01)>>0 
+#define set_obj_MA_PMcfg_SE_A__lf_gain_ol(o, y)      \
+  ({                                                 \
+    uint8_t __ret = o.read(21);                      \
+    o.write(21, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_SE_A__lf_gain_ol(y)                   \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(21);                      \
+    ma_write_byte(21, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_SE_A__lf_gain_ol(o) (o.read(21) & 0x01) >> 0
+#define get_MA_PMcfg_SE_A__lf_gain_ol() (ma_read_byte(21) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_SE_B.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_SE_B__lf_gain_ol__a 22
 #define MA_PMcfg_SE_B__lf_gain_ol__len 1
 #define MA_PMcfg_SE_B__lf_gain_ol__mask 0x01
 #define MA_PMcfg_SE_B__lf_gain_ol__shift 0x00
 #define MA_PMcfg_SE_B__lf_gain_ol__reset 0x00
-#define set_obj_MA_PMcfg_SE_B__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(22); o.write(22,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_SE_B__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(22); ma_write_byte(22,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_SE_B__lf_gain_ol(o) (o.read(22) & 0x01)>>0 
-#define get_MA_PMcfg_SE_B__lf_gain_ol() ( ma_read_byte(22) & 0x01)>>0 
+#define set_obj_MA_PMcfg_SE_B__lf_gain_ol(o, y)      \
+  ({                                                 \
+    uint8_t __ret = o.read(22);                      \
+    o.write(22, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_SE_B__lf_gain_ol(y)                   \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(22);                      \
+    ma_write_byte(22, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_SE_B__lf_gain_ol(o) (o.read(22) & 0x01) >> 0
+#define get_MA_PMcfg_SE_B__lf_gain_ol() (ma_read_byte(22) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_SE_B.freqDiv---
-//  
+//
 #define MA_PMcfg_SE_B__freqDiv__a 22
 #define MA_PMcfg_SE_B__freqDiv__len 2
 #define MA_PMcfg_SE_B__freqDiv__mask 0x06
 #define MA_PMcfg_SE_B__freqDiv__shift 0x01
 #define MA_PMcfg_SE_B__freqDiv__reset 0x01
-#define set_obj_MA_PMcfg_SE_B__freqDiv(o,y) ({ uint8_t __ret = o.read(22); o.write(22,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_SE_B__freqDiv(y) ({ uint8_t __ret = ma_read_byte(22); ma_write_byte(22,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_SE_B__freqDiv(o) (o.read(22) & 0x06)>>1 
-#define get_MA_PMcfg_SE_B__freqDiv() ( ma_read_byte(22) & 0x06)>>1 
+#define set_obj_MA_PMcfg_SE_B__freqDiv(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(22);                      \
+    o.write(22, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_SE_B__freqDiv(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(22);                      \
+    ma_write_byte(22, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_SE_B__freqDiv(o) (o.read(22) & 0x06) >> 1
+#define get_MA_PMcfg_SE_B__freqDiv() (ma_read_byte(22) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_SE_B.modType---
-//  
+//
 #define MA_PMcfg_SE_B__modType__a 22
 #define MA_PMcfg_SE_B__modType__len 2
 #define MA_PMcfg_SE_B__modType__mask 0x18
 #define MA_PMcfg_SE_B__modType__shift 0x03
 #define MA_PMcfg_SE_B__modType__reset 0x01
-#define set_obj_MA_PMcfg_SE_B__modType(o,y) ({ uint8_t __ret = o.read(22); o.write(22,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_SE_B__modType(y) ({ uint8_t __ret = ma_read_byte(22); ma_write_byte(22,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_SE_B__modType(o) (o.read(22) & 0x18)>>3 
-#define get_MA_PMcfg_SE_B__modType() ( ma_read_byte(22) & 0x18)>>3 
+#define set_obj_MA_PMcfg_SE_B__modType(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(22);                      \
+    o.write(22, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_SE_B__modType(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(22);                      \
+    ma_write_byte(22, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_SE_B__modType(o) (o.read(22) & 0x18) >> 3
+#define get_MA_PMcfg_SE_B__modType() (ma_read_byte(22) & 0x18) >> 3
 //------------------------------------------------------------------------------balWaitCount_PM1---
-// PM1 balancing period. 
+// PM1 balancing period.
 #define MA_balWaitCount_PM1__a 23
 #define MA_balWaitCount_PM1__len 8
 #define MA_balWaitCount_PM1__mask 0xff
 #define MA_balWaitCount_PM1__shift 0x00
 #define MA_balWaitCount_PM1__reset 0x14
-#define set_obj_MA_balWaitCount_PM1(o,y) o.write(23,y);
-#define set_MA_balWaitCount_PM1(y) ma_write_byte(23,y);
-#define get_obj_MA_balWaitCount_PM1(o) (o.read(23) & 0xff)>>0 
-#define get_MA_balWaitCount_PM1() ( ma_read_byte(23) & 0xff)>>0 
+#define set_obj_MA_balWaitCount_PM1(o, y) o.write(23, y);
+#define set_MA_balWaitCount_PM1(y) ma_write_byte(23, y);
+#define get_obj_MA_balWaitCount_PM1(o) (o.read(23) & 0xff) >> 0
+#define get_MA_balWaitCount_PM1() (ma_read_byte(23) & 0xff) >> 0
 //------------------------------------------------------------------------------balWaitCount_PM2---
-// PM2 balancing period. 
+// PM2 balancing period.
 #define MA_balWaitCount_PM2__a 24
 #define MA_balWaitCount_PM2__len 8
 #define MA_balWaitCount_PM2__mask 0xff
 #define MA_balWaitCount_PM2__shift 0x00
 #define MA_balWaitCount_PM2__reset 0x14
-#define set_obj_MA_balWaitCount_PM2(o,y) o.write(24,y);
-#define set_MA_balWaitCount_PM2(y) ma_write_byte(24,y);
-#define get_obj_MA_balWaitCount_PM2(o) (o.read(24) & 0xff)>>0 
-#define get_MA_balWaitCount_PM2() ( ma_read_byte(24) & 0xff)>>0 
+#define set_obj_MA_balWaitCount_PM2(o, y) o.write(24, y);
+#define set_MA_balWaitCount_PM2(y) ma_write_byte(24, y);
+#define get_obj_MA_balWaitCount_PM2(o) (o.read(24) & 0xff) >> 0
+#define get_MA_balWaitCount_PM2() (ma_read_byte(24) & 0xff) >> 0
 //------------------------------------------------------------------------------balWaitCount_PM3---
-// PM3 balancing period. 
+// PM3 balancing period.
 #define MA_balWaitCount_PM3__a 25
 #define MA_balWaitCount_PM3__len 8
 #define MA_balWaitCount_PM3__mask 0xff
 #define MA_balWaitCount_PM3__shift 0x00
 #define MA_balWaitCount_PM3__reset 0x1a
-#define set_obj_MA_balWaitCount_PM3(o,y) o.write(25,y);
-#define set_MA_balWaitCount_PM3(y) ma_write_byte(25,y);
-#define get_obj_MA_balWaitCount_PM3(o) (o.read(25) & 0xff)>>0 
-#define get_MA_balWaitCount_PM3() ( ma_read_byte(25) & 0xff)>>0 
+#define set_obj_MA_balWaitCount_PM3(o, y) o.write(25, y);
+#define set_MA_balWaitCount_PM3(y) ma_write_byte(25, y);
+#define get_obj_MA_balWaitCount_PM3(o) (o.read(25) & 0xff) >> 0
+#define get_MA_balWaitCount_PM3() (ma_read_byte(25) & 0xff) >> 0
 //------------------------------------------------------------------------------useSpread_PM1---
-// PM1 PWM spread-spectrum mode on/off. 
+// PM1 PWM spread-spectrum mode on/off.
 #define MA_useSpread_PM1__a 26
 #define MA_useSpread_PM1__len 1
 #define MA_useSpread_PM1__mask 0x40
 #define MA_useSpread_PM1__shift 0x06
 #define MA_useSpread_PM1__reset 0x00
-#define set_obj_MA_useSpread_PM1(o,y) ({ uint8_t __ret = o.read(26); o.write(26,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_useSpread_PM1(y) ({ uint8_t __ret = ma_read_byte(26); ma_write_byte(26,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_useSpread_PM1(o) (o.read(26) & 0x40)>>6 
-#define get_MA_useSpread_PM1() ( ma_read_byte(26) & 0x40)>>6 
+#define set_obj_MA_useSpread_PM1(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(26);                      \
+    o.write(26, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_useSpread_PM1(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(26);                      \
+    ma_write_byte(26, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_useSpread_PM1(o) (o.read(26) & 0x40) >> 6
+#define get_MA_useSpread_PM1() (ma_read_byte(26) & 0x40) >> 6
 //------------------------------------------------------------------------------DTsteps_PM1---
-// PM1 dead time setting [10ns steps]. 
+// PM1 dead time setting [10ns steps].
 #define MA_DTsteps_PM1__a 26
 #define MA_DTsteps_PM1__len 3
 #define MA_DTsteps_PM1__mask 0x38
 #define MA_DTsteps_PM1__shift 0x03
 #define MA_DTsteps_PM1__reset 0x04
-#define set_obj_MA_DTsteps_PM1(o,y) ({ uint8_t __ret = o.read(26); o.write(26,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define set_MA_DTsteps_PM1(y) ({ uint8_t __ret = ma_read_byte(26); ma_write_byte(26,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define get_obj_MA_DTsteps_PM1(o) (o.read(26) & 0x38)>>3 
-#define get_MA_DTsteps_PM1() ( ma_read_byte(26) & 0x38)>>3 
+#define set_obj_MA_DTsteps_PM1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(26);                      \
+    o.write(26, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define set_MA_DTsteps_PM1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(26);                      \
+    ma_write_byte(26, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define get_obj_MA_DTsteps_PM1(o) (o.read(26) & 0x38) >> 3
+#define get_MA_DTsteps_PM1() (ma_read_byte(26) & 0x38) >> 3
 //------------------------------------------------------------------------------balType_PM1---
-// PM1 balancing sensor scheme. 
+// PM1 balancing sensor scheme.
 #define MA_balType_PM1__a 26
 #define MA_balType_PM1__len 3
 #define MA_balType_PM1__mask 0x07
 #define MA_balType_PM1__shift 0x00
 #define MA_balType_PM1__reset 0x00
-#define set_obj_MA_balType_PM1(o,y) ({ uint8_t __ret = o.read(26); o.write(26,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_balType_PM1(y) ({ uint8_t __ret = ma_read_byte(26); ma_write_byte(26,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_balType_PM1(o) (o.read(26) & 0x07)>>0 
-#define get_MA_balType_PM1() ( ma_read_byte(26) & 0x07)>>0 
+#define set_obj_MA_balType_PM1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(26);                      \
+    o.write(26, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_balType_PM1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(26);                      \
+    ma_write_byte(26, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_balType_PM1(o) (o.read(26) & 0x07) >> 0
+#define get_MA_balType_PM1() (ma_read_byte(26) & 0x07) >> 0
 //------------------------------------------------------------------------------useSpread_PM2---
-// PM2 PWM spread-spectrum mode on/off. 
+// PM2 PWM spread-spectrum mode on/off.
 #define MA_useSpread_PM2__a 27
 #define MA_useSpread_PM2__len 1
 #define MA_useSpread_PM2__mask 0x40
 #define MA_useSpread_PM2__shift 0x06
 #define MA_useSpread_PM2__reset 0x00
-#define set_obj_MA_useSpread_PM2(o,y) ({ uint8_t __ret = o.read(27); o.write(27,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_useSpread_PM2(y) ({ uint8_t __ret = ma_read_byte(27); ma_write_byte(27,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_useSpread_PM2(o) (o.read(27) & 0x40)>>6 
-#define get_MA_useSpread_PM2() ( ma_read_byte(27) & 0x40)>>6 
+#define set_obj_MA_useSpread_PM2(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(27);                      \
+    o.write(27, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_useSpread_PM2(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(27);                      \
+    ma_write_byte(27, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_useSpread_PM2(o) (o.read(27) & 0x40) >> 6
+#define get_MA_useSpread_PM2() (ma_read_byte(27) & 0x40) >> 6
 //------------------------------------------------------------------------------DTsteps_PM2---
-// PM2 dead time setting [10ns steps]. 
+// PM2 dead time setting [10ns steps].
 #define MA_DTsteps_PM2__a 27
 #define MA_DTsteps_PM2__len 3
 #define MA_DTsteps_PM2__mask 0x38
 #define MA_DTsteps_PM2__shift 0x03
 #define MA_DTsteps_PM2__reset 0x03
-#define set_obj_MA_DTsteps_PM2(o,y) ({ uint8_t __ret = o.read(27); o.write(27,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define set_MA_DTsteps_PM2(y) ({ uint8_t __ret = ma_read_byte(27); ma_write_byte(27,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define get_obj_MA_DTsteps_PM2(o) (o.read(27) & 0x38)>>3 
-#define get_MA_DTsteps_PM2() ( ma_read_byte(27) & 0x38)>>3 
+#define set_obj_MA_DTsteps_PM2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(27);                      \
+    o.write(27, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define set_MA_DTsteps_PM2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(27);                      \
+    ma_write_byte(27, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define get_obj_MA_DTsteps_PM2(o) (o.read(27) & 0x38) >> 3
+#define get_MA_DTsteps_PM2() (ma_read_byte(27) & 0x38) >> 3
 //------------------------------------------------------------------------------balType_PM2---
-// PM2 balancing sensor scheme. 
+// PM2 balancing sensor scheme.
 #define MA_balType_PM2__a 27
 #define MA_balType_PM2__len 3
 #define MA_balType_PM2__mask 0x07
 #define MA_balType_PM2__shift 0x00
 #define MA_balType_PM2__reset 0x01
-#define set_obj_MA_balType_PM2(o,y) ({ uint8_t __ret = o.read(27); o.write(27,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_balType_PM2(y) ({ uint8_t __ret = ma_read_byte(27); ma_write_byte(27,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_balType_PM2(o) (o.read(27) & 0x07)>>0 
-#define get_MA_balType_PM2() ( ma_read_byte(27) & 0x07)>>0 
+#define set_obj_MA_balType_PM2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(27);                      \
+    o.write(27, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_balType_PM2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(27);                      \
+    ma_write_byte(27, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_balType_PM2(o) (o.read(27) & 0x07) >> 0
+#define get_MA_balType_PM2() (ma_read_byte(27) & 0x07) >> 0
 //------------------------------------------------------------------------------useSpread_PM3---
-// PM3 PWM spread-spectrum mode on/off. 
+// PM3 PWM spread-spectrum mode on/off.
 #define MA_useSpread_PM3__a 28
 #define MA_useSpread_PM3__len 1
 #define MA_useSpread_PM3__mask 0x40
 #define MA_useSpread_PM3__shift 0x06
 #define MA_useSpread_PM3__reset 0x00
-#define set_obj_MA_useSpread_PM3(o,y) ({ uint8_t __ret = o.read(28); o.write(28,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_useSpread_PM3(y) ({ uint8_t __ret = ma_read_byte(28); ma_write_byte(28,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_useSpread_PM3(o) (o.read(28) & 0x40)>>6 
-#define get_MA_useSpread_PM3() ( ma_read_byte(28) & 0x40)>>6 
+#define set_obj_MA_useSpread_PM3(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(28);                      \
+    o.write(28, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_useSpread_PM3(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(28);                      \
+    ma_write_byte(28, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_useSpread_PM3(o) (o.read(28) & 0x40) >> 6
+#define get_MA_useSpread_PM3() (ma_read_byte(28) & 0x40) >> 6
 //------------------------------------------------------------------------------DTsteps_PM3---
-// PM3 dead time setting [10ns steps]. 
+// PM3 dead time setting [10ns steps].
 #define MA_DTsteps_PM3__a 28
 #define MA_DTsteps_PM3__len 3
 #define MA_DTsteps_PM3__mask 0x38
 #define MA_DTsteps_PM3__shift 0x03
 #define MA_DTsteps_PM3__reset 0x01
-#define set_obj_MA_DTsteps_PM3(o,y) ({ uint8_t __ret = o.read(28); o.write(28,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define set_MA_DTsteps_PM3(y) ({ uint8_t __ret = ma_read_byte(28); ma_write_byte(28,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define get_obj_MA_DTsteps_PM3(o) (o.read(28) & 0x38)>>3 
-#define get_MA_DTsteps_PM3() ( ma_read_byte(28) & 0x38)>>3 
+#define set_obj_MA_DTsteps_PM3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(28);                      \
+    o.write(28, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define set_MA_DTsteps_PM3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(28);                      \
+    ma_write_byte(28, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define get_obj_MA_DTsteps_PM3(o) (o.read(28) & 0x38) >> 3
+#define get_MA_DTsteps_PM3() (ma_read_byte(28) & 0x38) >> 3
 //------------------------------------------------------------------------------balType_PM3---
-// PM3 balancing sensor scheme. 
+// PM3 balancing sensor scheme.
 #define MA_balType_PM3__a 28
 #define MA_balType_PM3__len 3
 #define MA_balType_PM3__mask 0x07
 #define MA_balType_PM3__shift 0x00
 #define MA_balType_PM3__reset 0x03
-#define set_obj_MA_balType_PM3(o,y) ({ uint8_t __ret = o.read(28); o.write(28,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_balType_PM3(y) ({ uint8_t __ret = ma_read_byte(28); ma_write_byte(28,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_balType_PM3(o) (o.read(28) & 0x07)>>0 
-#define get_MA_balType_PM3() ( ma_read_byte(28) & 0x07)>>0 
+#define set_obj_MA_balType_PM3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(28);                      \
+    o.write(28, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_balType_PM3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(28);                      \
+    ma_write_byte(28, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_balType_PM3(o) (o.read(28) & 0x07) >> 0
+#define get_MA_balType_PM3() (ma_read_byte(28) & 0x07) >> 0
 //------------------------------------------------------------------------------PMprofile---
-// PM profile select. Valid presets: 0-1-2-3-4. 5=> custom profile. 
+// PM profile select. Valid presets: 0-1-2-3-4. 5=> custom profile.
 #define MA_PMprofile__a 29
 #define MA_PMprofile__len 3
 #define MA_PMprofile__mask 0x07
 #define MA_PMprofile__shift 0x00
 #define MA_PMprofile__reset 0x00
-#define set_obj_MA_PMprofile(o,y) ({ uint8_t __ret = o.read(29); o.write(29,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_PMprofile(y) ({ uint8_t __ret = ma_read_byte(29); ma_write_byte(29,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_PMprofile(o) (o.read(29) & 0x07)>>0 
-#define get_MA_PMprofile() ( ma_read_byte(29) & 0x07)>>0 
+#define set_obj_MA_PMprofile(o, y)                   \
+  ({                                                 \
+    uint8_t __ret = o.read(29);                      \
+    o.write(29, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_PMprofile(y)                                \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(29);                      \
+    ma_write_byte(29, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_PMprofile(o) (o.read(29) & 0x07) >> 0
+#define get_MA_PMprofile() (ma_read_byte(29) & 0x07) >> 0
 //------------------------------------------------------------------------------PM3_man---
-// Custom profile PM3 contents. 0=>A, 1=>B, 2=>C, 3=>D 
+// Custom profile PM3 contents. 0=>A, 1=>B, 2=>C, 3=>D
 #define MA_PM3_man__a 30
 #define MA_PM3_man__len 2
 #define MA_PM3_man__mask 0x30
 #define MA_PM3_man__shift 0x04
 #define MA_PM3_man__reset 0x02
-#define set_obj_MA_PM3_man(o,y) ({ uint8_t __ret = o.read(30); o.write(30,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_PM3_man(y) ({ uint8_t __ret = ma_read_byte(30); ma_write_byte(30,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_PM3_man(o) (o.read(30) & 0x30)>>4 
-#define get_MA_PM3_man() ( ma_read_byte(30) & 0x30)>>4 
+#define set_obj_MA_PM3_man(o, y)                     \
+  ({                                                 \
+    uint8_t __ret = o.read(30);                      \
+    o.write(30, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_PM3_man(y)                                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(30);                      \
+    ma_write_byte(30, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_PM3_man(o) (o.read(30) & 0x30) >> 4
+#define get_MA_PM3_man() (ma_read_byte(30) & 0x30) >> 4
 //------------------------------------------------------------------------------PM2_man---
-// Custom profile PM2 contents. 0=>A, 1=>B, 2=>C, 3=>D 
+// Custom profile PM2 contents. 0=>A, 1=>B, 2=>C, 3=>D
 #define MA_PM2_man__a 30
 #define MA_PM2_man__len 2
 #define MA_PM2_man__mask 0x0c
 #define MA_PM2_man__shift 0x02
 #define MA_PM2_man__reset 0x03
-#define set_obj_MA_PM2_man(o,y) ({ uint8_t __ret = o.read(30); o.write(30,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define set_MA_PM2_man(y) ({ uint8_t __ret = ma_read_byte(30); ma_write_byte(30,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define get_obj_MA_PM2_man(o) (o.read(30) & 0x0c)>>2 
-#define get_MA_PM2_man() ( ma_read_byte(30) & 0x0c)>>2 
+#define set_obj_MA_PM2_man(o, y)                     \
+  ({                                                 \
+    uint8_t __ret = o.read(30);                      \
+    o.write(30, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define set_MA_PM2_man(y)                                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(30);                      \
+    ma_write_byte(30, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define get_obj_MA_PM2_man(o) (o.read(30) & 0x0c) >> 2
+#define get_MA_PM2_man() (ma_read_byte(30) & 0x0c) >> 2
 //------------------------------------------------------------------------------PM1_man---
-// Custom profile PM1 contents. 0=>A, 1=>B, 2=>C, 3=>D 
+// Custom profile PM1 contents. 0=>A, 1=>B, 2=>C, 3=>D
 #define MA_PM1_man__a 30
 #define MA_PM1_man__len 2
 #define MA_PM1_man__mask 0x03
 #define MA_PM1_man__shift 0x00
 #define MA_PM1_man__reset 0x03
-#define set_obj_MA_PM1_man(o,y) ({ uint8_t __ret = o.read(30); o.write(30,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_PM1_man(y) ({ uint8_t __ret = ma_read_byte(30); ma_write_byte(30,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_PM1_man(o) (o.read(30) & 0x03)>>0 
-#define get_MA_PM1_man() ( ma_read_byte(30) & 0x03)>>0 
+#define set_obj_MA_PM1_man(o, y)                     \
+  ({                                                 \
+    uint8_t __ret = o.read(30);                      \
+    o.write(30, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_PM1_man(y)                                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(30);                      \
+    ma_write_byte(30, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_PM1_man(o) (o.read(30) & 0x03) >> 0
+#define get_MA_PM1_man() (ma_read_byte(30) & 0x03) >> 0
 //------------------------------------------------------------------------------ocp_latch_clear---
-// Low-high clears current OCP latched condition. 
+// Low-high clears current OCP latched condition.
 #define MA_ocp_latch_clear__a 32
 #define MA_ocp_latch_clear__len 1
 #define MA_ocp_latch_clear__mask 0x80
 #define MA_ocp_latch_clear__shift 0x07
 #define MA_ocp_latch_clear__reset 0x00
-#define set_obj_MA_ocp_latch_clear(o,y) ({ uint8_t __ret = o.read(32); o.write(32,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_ocp_latch_clear(y) ({ uint8_t __ret = ma_read_byte(32); ma_write_byte(32,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_ocp_latch_clear(o) (o.read(32) & 0x80)>>7 
-#define get_MA_ocp_latch_clear() ( ma_read_byte(32) & 0x80)>>7 
+#define set_obj_MA_ocp_latch_clear(o, y)             \
+  ({                                                 \
+    uint8_t __ret = o.read(32);                      \
+    o.write(32, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_ocp_latch_clear(y)                          \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(32);                      \
+    ma_write_byte(32, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_ocp_latch_clear(o) (o.read(32) & 0x80) >> 7
+#define get_MA_ocp_latch_clear() (ma_read_byte(32) & 0x80) >> 7
 //------------------------------------------------------------------------------audio_in_mode---
-// Audio input mode; 0-1-2-3-4-5 
+// Audio input mode; 0-1-2-3-4-5
 #define MA_audio_in_mode__a 37
 #define MA_audio_in_mode__len 3
 #define MA_audio_in_mode__mask 0xe0
 #define MA_audio_in_mode__shift 0x05
 #define MA_audio_in_mode__reset 0x00
-#define set_obj_MA_audio_in_mode(o,y) ({ uint8_t __ret = o.read(37); o.write(37,(__ret&0x1f)|((y<<5)&0xe0)); }) 
-#define set_MA_audio_in_mode(y) ({ uint8_t __ret = ma_read_byte(37); ma_write_byte(37,(__ret&0x1f)|((y<<5)&0xe0)); }) 
-#define get_obj_MA_audio_in_mode(o) (o.read(37) & 0xe0)>>5 
-#define get_MA_audio_in_mode() ( ma_read_byte(37) & 0xe0)>>5 
+#define set_obj_MA_audio_in_mode(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(37);                      \
+    o.write(37, (__ret & 0x1f) | ((y << 5) & 0xe0)); \
+  })
+#define set_MA_audio_in_mode(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(37);                      \
+    ma_write_byte(37, (__ret & 0x1f) | ((y << 5) & 0xe0)); \
+  })
+#define get_obj_MA_audio_in_mode(o) (o.read(37) & 0xe0) >> 5
+#define get_MA_audio_in_mode() (ma_read_byte(37) & 0xe0) >> 5
 //------------------------------------------------------------------------------eh_dcShdn---
-// High to enable DC protection 
+// High to enable DC protection
 #define MA_eh_dcShdn__a 38
 #define MA_eh_dcShdn__len 1
 #define MA_eh_dcShdn__mask 0x04
 #define MA_eh_dcShdn__shift 0x02
 #define MA_eh_dcShdn__reset 0x01
-#define set_obj_MA_eh_dcShdn(o,y) ({ uint8_t __ret = o.read(38); o.write(38,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_eh_dcShdn(y) ({ uint8_t __ret = ma_read_byte(38); ma_write_byte(38,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_eh_dcShdn(o) (o.read(38) & 0x04)>>2 
-#define get_MA_eh_dcShdn() ( ma_read_byte(38) & 0x04)>>2 
+#define set_obj_MA_eh_dcShdn(o, y)                   \
+  ({                                                 \
+    uint8_t __ret = o.read(38);                      \
+    o.write(38, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_eh_dcShdn(y)                                \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(38);                      \
+    ma_write_byte(38, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_eh_dcShdn(o) (o.read(38) & 0x04) >> 2
+#define get_MA_eh_dcShdn() (ma_read_byte(38) & 0x04) >> 2
 //------------------------------------------------------------------------------audio_in_mode_ext---
-// If set, audio_in_mode is controlled from audio_in_mode register. If not set  audio_in_mode is set from fuse bank setting 
+// If set, audio_in_mode is controlled from audio_in_mode register. If not set
+// audio_in_mode is set from fuse bank setting
 #define MA_audio_in_mode_ext__a 39
 #define MA_audio_in_mode_ext__len 1
 #define MA_audio_in_mode_ext__mask 0x20
 #define MA_audio_in_mode_ext__shift 0x05
 #define MA_audio_in_mode_ext__reset 0x00
-#define set_obj_MA_audio_in_mode_ext(o,y) ({ uint8_t __ret = o.read(39); o.write(39,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_audio_in_mode_ext(y) ({ uint8_t __ret = ma_read_byte(39); ma_write_byte(39,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_audio_in_mode_ext(o) (o.read(39) & 0x20)>>5 
-#define get_MA_audio_in_mode_ext() ( ma_read_byte(39) & 0x20)>>5 
+#define set_obj_MA_audio_in_mode_ext(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(39);                      \
+    o.write(39, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_audio_in_mode_ext(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(39);                      \
+    ma_write_byte(39, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_audio_in_mode_ext(o) (o.read(39) & 0x20) >> 5
+#define get_MA_audio_in_mode_ext() (ma_read_byte(39) & 0x20) >> 5
 //------------------------------------------------------------------------------eh_clear---
-// Flip to clear error registers 
+// Flip to clear error registers
 #define MA_eh_clear__a 45
 #define MA_eh_clear__len 1
 #define MA_eh_clear__mask 0x04
 #define MA_eh_clear__shift 0x02
 #define MA_eh_clear__reset 0x00
-#define set_obj_MA_eh_clear(o,y) ({ uint8_t __ret = o.read(45); o.write(45,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_eh_clear(y) ({ uint8_t __ret = ma_read_byte(45); ma_write_byte(45,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_eh_clear(o) (o.read(45) & 0x04)>>2 
-#define get_MA_eh_clear() ( ma_read_byte(45) & 0x04)>>2 
+#define set_obj_MA_eh_clear(o, y)                    \
+  ({                                                 \
+    uint8_t __ret = o.read(45);                      \
+    o.write(45, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_eh_clear(y)                                 \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(45);                      \
+    ma_write_byte(45, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_eh_clear(o) (o.read(45) & 0x04) >> 2
+#define get_MA_eh_clear() (ma_read_byte(45) & 0x04) >> 2
 //------------------------------------------------------------------------------thermal_compr_en---
-// Enable otw-contr.  input compression? 
+// Enable otw-contr.  input compression?
 #define MA_thermal_compr_en__a 45
 #define MA_thermal_compr_en__len 1
 #define MA_thermal_compr_en__mask 0x20
 #define MA_thermal_compr_en__shift 0x05
 #define MA_thermal_compr_en__reset 0x01
-#define set_obj_MA_thermal_compr_en(o,y) ({ uint8_t __ret = o.read(45); o.write(45,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_thermal_compr_en(y) ({ uint8_t __ret = ma_read_byte(45); ma_write_byte(45,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_thermal_compr_en(o) (o.read(45) & 0x20)>>5 
-#define get_MA_thermal_compr_en() ( ma_read_byte(45) & 0x20)>>5 
+#define set_obj_MA_thermal_compr_en(o, y)            \
+  ({                                                 \
+    uint8_t __ret = o.read(45);                      \
+    o.write(45, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_thermal_compr_en(y)                         \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(45);                      \
+    ma_write_byte(45, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_thermal_compr_en(o) (o.read(45) & 0x20) >> 5
+#define get_MA_thermal_compr_en() (ma_read_byte(45) & 0x20) >> 5
 //------------------------------------------------------------------------------system_mute---
-// 1 = mute system, 0 = normal operation 
+// 1 = mute system, 0 = normal operation
 #define MA_system_mute__a 45
 #define MA_system_mute__len 1
 #define MA_system_mute__mask 0x40
 #define MA_system_mute__shift 0x06
 #define MA_system_mute__reset 0x00
-#define set_obj_MA_system_mute(o,y) ({ uint8_t __ret = o.read(45); o.write(45,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_system_mute(y) ({ uint8_t __ret = ma_read_byte(45); ma_write_byte(45,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_system_mute(o) (o.read(45) & 0x40)>>6 
-#define get_MA_system_mute() ( ma_read_byte(45) & 0x40)>>6 
+#define set_obj_MA_system_mute(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(45);                      \
+    o.write(45, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_system_mute(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(45);                      \
+    ma_write_byte(45, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_system_mute(o) (o.read(45) & 0x40) >> 6
+#define get_MA_system_mute() (ma_read_byte(45) & 0x40) >> 6
 //------------------------------------------------------------------------------thermal_compr_max_db---
-// Audio limiter max thermal reduction 
+// Audio limiter max thermal reduction
 #define MA_thermal_compr_max_db__a 46
 #define MA_thermal_compr_max_db__len 3
 #define MA_thermal_compr_max_db__mask 0x07
 #define MA_thermal_compr_max_db__shift 0x00
 #define MA_thermal_compr_max_db__reset 0x04
-#define set_obj_MA_thermal_compr_max_db(o,y) ({ uint8_t __ret = o.read(46); o.write(46,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_thermal_compr_max_db(y) ({ uint8_t __ret = ma_read_byte(46); ma_write_byte(46,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_thermal_compr_max_db(o) (o.read(46) & 0x07)>>0 
-#define get_MA_thermal_compr_max_db() ( ma_read_byte(46) & 0x07)>>0 
+#define set_obj_MA_thermal_compr_max_db(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(46);                      \
+    o.write(46, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_thermal_compr_max_db(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(46);                      \
+    ma_write_byte(46, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_thermal_compr_max_db(o) (o.read(46) & 0x07) >> 0
+#define get_MA_thermal_compr_max_db() (ma_read_byte(46) & 0x07) >> 0
 //------------------------------------------------------------------------------audio_proc_enable---
-// Enable Audio proc, bypass if not enabled 
+// Enable Audio proc, bypass if not enabled
 #define MA_audio_proc_enable__a 53
 #define MA_audio_proc_enable__len 1
 #define MA_audio_proc_enable__mask 0x08
 #define MA_audio_proc_enable__shift 0x03
 #define MA_audio_proc_enable__reset 0x00
-#define set_obj_MA_audio_proc_enable(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define set_MA_audio_proc_enable(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define get_obj_MA_audio_proc_enable(o) (o.read(53) & 0x08)>>3 
-#define get_MA_audio_proc_enable() ( ma_read_byte(53) & 0x08)>>3 
+#define set_obj_MA_audio_proc_enable(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define set_MA_audio_proc_enable(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define get_obj_MA_audio_proc_enable(o) (o.read(53) & 0x08) >> 3
+#define get_MA_audio_proc_enable() (ma_read_byte(53) & 0x08) >> 3
 //------------------------------------------------------------------------------audio_proc_release---
-// 00:slow, 01:normal, 10:fast 
+// 00:slow, 01:normal, 10:fast
 #define MA_audio_proc_release__a 53
 #define MA_audio_proc_release__len 2
 #define MA_audio_proc_release__mask 0x30
 #define MA_audio_proc_release__shift 0x04
 #define MA_audio_proc_release__reset 0x00
-#define set_obj_MA_audio_proc_release(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_audio_proc_release(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_audio_proc_release(o) (o.read(53) & 0x30)>>4 
-#define get_MA_audio_proc_release() ( ma_read_byte(53) & 0x30)>>4 
+#define set_obj_MA_audio_proc_release(o, y)          \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_audio_proc_release(y)                       \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_audio_proc_release(o) (o.read(53) & 0x30) >> 4
+#define get_MA_audio_proc_release() (ma_read_byte(53) & 0x30) >> 4
 //------------------------------------------------------------------------------audio_proc_attack---
-// 00:slow, 01:normal, 10:fast  
+// 00:slow, 01:normal, 10:fast
 #define MA_audio_proc_attack__a 53
 #define MA_audio_proc_attack__len 2
 #define MA_audio_proc_attack__mask 0xc0
 #define MA_audio_proc_attack__shift 0x06
 #define MA_audio_proc_attack__reset 0x00
-#define set_obj_MA_audio_proc_attack(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define set_MA_audio_proc_attack(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define get_obj_MA_audio_proc_attack(o) (o.read(53) & 0xc0)>>6 
-#define get_MA_audio_proc_attack() ( ma_read_byte(53) & 0xc0)>>6 
+#define set_obj_MA_audio_proc_attack(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define set_MA_audio_proc_attack(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define get_obj_MA_audio_proc_attack(o) (o.read(53) & 0xc0) >> 6
+#define get_MA_audio_proc_attack() (ma_read_byte(53) & 0xc0) >> 6
 //------------------------------------------------------------------------------i2s_format---
-// i2s basic data format, 000 = std. i2s, 001 = left justified (default) 
+// i2s basic data format, 000 = std. i2s, 001 = left justified (default)
 #define MA_i2s_format__a 53
 #define MA_i2s_format__len 3
 #define MA_i2s_format__mask 0x07
 #define MA_i2s_format__shift 0x00
 #define MA_i2s_format__reset 0x01
-#define set_obj_MA_i2s_format(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_i2s_format(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_i2s_format(o) (o.read(53) & 0x07)>>0 
-#define get_MA_i2s_format() ( ma_read_byte(53) & 0x07)>>0 
+#define set_obj_MA_i2s_format(o, y)                  \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_i2s_format(y)                               \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_i2s_format(o) (o.read(53) & 0x07) >> 0
+#define get_MA_i2s_format() (ma_read_byte(53) & 0x07) >> 0
 //------------------------------------------------------------------------------audio_proc_limiterEnable---
-// 1: enable limiter, 0: disable limiter 
+// 1: enable limiter, 0: disable limiter
 #define MA_audio_proc_limiterEnable__a 54
 #define MA_audio_proc_limiterEnable__len 1
 #define MA_audio_proc_limiterEnable__mask 0x40
 #define MA_audio_proc_limiterEnable__shift 0x06
 #define MA_audio_proc_limiterEnable__reset 0x00
-#define set_obj_MA_audio_proc_limiterEnable(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_audio_proc_limiterEnable(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_audio_proc_limiterEnable(o) (o.read(54) & 0x40)>>6 
-#define get_MA_audio_proc_limiterEnable() ( ma_read_byte(54) & 0x40)>>6 
+#define set_obj_MA_audio_proc_limiterEnable(o, y)    \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_audio_proc_limiterEnable(y)                 \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_audio_proc_limiterEnable(o) (o.read(54) & 0x40) >> 6
+#define get_MA_audio_proc_limiterEnable() (ma_read_byte(54) & 0x40) >> 6
 //------------------------------------------------------------------------------audio_proc_mute---
-// 1: mute, 0: unmute 
+// 1: mute, 0: unmute
 #define MA_audio_proc_mute__a 54
 #define MA_audio_proc_mute__len 1
 #define MA_audio_proc_mute__mask 0x80
 #define MA_audio_proc_mute__shift 0x07
 #define MA_audio_proc_mute__reset 0x00
-#define set_obj_MA_audio_proc_mute(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_audio_proc_mute(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_audio_proc_mute(o) (o.read(54) & 0x80)>>7 
-#define get_MA_audio_proc_mute() ( ma_read_byte(54) & 0x80)>>7 
+#define set_obj_MA_audio_proc_mute(o, y)             \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_audio_proc_mute(y)                          \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_audio_proc_mute(o) (o.read(54) & 0x80) >> 7
+#define get_MA_audio_proc_mute() (ma_read_byte(54) & 0x80) >> 7
 //------------------------------------------------------------------------------i2s_sck_pol---
-// i2s sck polarity cfg. 0 = rising edge data change 
+// i2s sck polarity cfg. 0 = rising edge data change
 #define MA_i2s_sck_pol__a 54
 #define MA_i2s_sck_pol__len 1
 #define MA_i2s_sck_pol__mask 0x01
 #define MA_i2s_sck_pol__shift 0x00
 #define MA_i2s_sck_pol__reset 0x01
-#define set_obj_MA_i2s_sck_pol(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_i2s_sck_pol(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_i2s_sck_pol(o) (o.read(54) & 0x01)>>0 
-#define get_MA_i2s_sck_pol() ( ma_read_byte(54) & 0x01)>>0 
+#define set_obj_MA_i2s_sck_pol(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_i2s_sck_pol(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_i2s_sck_pol(o) (o.read(54) & 0x01) >> 0
+#define get_MA_i2s_sck_pol() (ma_read_byte(54) & 0x01) >> 0
 //------------------------------------------------------------------------------i2s_framesize---
-// i2s word length. 00 = 32bit, 01 = 24bit 
+// i2s word length. 00 = 32bit, 01 = 24bit
 #define MA_i2s_framesize__a 54
 #define MA_i2s_framesize__len 2
 #define MA_i2s_framesize__mask 0x18
 #define MA_i2s_framesize__shift 0x03
 #define MA_i2s_framesize__reset 0x00
-#define set_obj_MA_i2s_framesize(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_i2s_framesize(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_i2s_framesize(o) (o.read(54) & 0x18)>>3 
-#define get_MA_i2s_framesize() ( ma_read_byte(54) & 0x18)>>3 
+#define set_obj_MA_i2s_framesize(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_i2s_framesize(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_i2s_framesize(o) (o.read(54) & 0x18) >> 3
+#define get_MA_i2s_framesize() (ma_read_byte(54) & 0x18) >> 3
 //------------------------------------------------------------------------------i2s_ws_pol---
-// i2s ws polarity. 0 = low first 
+// i2s ws polarity. 0 = low first
 #define MA_i2s_ws_pol__a 54
 #define MA_i2s_ws_pol__len 1
 #define MA_i2s_ws_pol__mask 0x02
 #define MA_i2s_ws_pol__shift 0x01
 #define MA_i2s_ws_pol__reset 0x00
-#define set_obj_MA_i2s_ws_pol(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_i2s_ws_pol(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_i2s_ws_pol(o) (o.read(54) & 0x02)>>1 
-#define get_MA_i2s_ws_pol() ( ma_read_byte(54) & 0x02)>>1 
+#define set_obj_MA_i2s_ws_pol(o, y)                  \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_i2s_ws_pol(y)                               \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_i2s_ws_pol(o) (o.read(54) & 0x02) >> 1
+#define get_MA_i2s_ws_pol() (ma_read_byte(54) & 0x02) >> 1
 //------------------------------------------------------------------------------i2s_order---
-// i2s word bit order. 0 = MSB first 
+// i2s word bit order. 0 = MSB first
 #define MA_i2s_order__a 54
 #define MA_i2s_order__len 1
 #define MA_i2s_order__mask 0x04
 #define MA_i2s_order__shift 0x02
 #define MA_i2s_order__reset 0x00
-#define set_obj_MA_i2s_order(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_i2s_order(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_i2s_order(o) (o.read(54) & 0x04)>>2 
-#define get_MA_i2s_order() ( ma_read_byte(54) & 0x04)>>2 
+#define set_obj_MA_i2s_order(o, y)                   \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_i2s_order(y)                                \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_i2s_order(o) (o.read(54) & 0x04) >> 2
+#define get_MA_i2s_order() (ma_read_byte(54) & 0x04) >> 2
 //------------------------------------------------------------------------------i2s_rightfirst---
-// i2s L/R word order; 0 = left first 
+// i2s L/R word order; 0 = left first
 #define MA_i2s_rightfirst__a 54
 #define MA_i2s_rightfirst__len 1
 #define MA_i2s_rightfirst__mask 0x20
 #define MA_i2s_rightfirst__shift 0x05
 #define MA_i2s_rightfirst__reset 0x00
-#define set_obj_MA_i2s_rightfirst(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_i2s_rightfirst(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_i2s_rightfirst(o) (o.read(54) & 0x20)>>5 
-#define get_MA_i2s_rightfirst() ( ma_read_byte(54) & 0x20)>>5 
+#define set_obj_MA_i2s_rightfirst(o, y)              \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_i2s_rightfirst(y)                           \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_i2s_rightfirst(o) (o.read(54) & 0x20) >> 5
+#define get_MA_i2s_rightfirst() (ma_read_byte(54) & 0x20) >> 5
 //------------------------------------------------------------------------------vol_db_master---
-// Master volume db 
+// Master volume db
 #define MA_vol_db_master__a 64
 #define MA_vol_db_master__len 8
 #define MA_vol_db_master__mask 0xff
 #define MA_vol_db_master__shift 0x00
 #define MA_vol_db_master__reset 0x18
-#define set_obj_MA_vol_db_master(o,y) o.write(64,y);
-#define set_MA_vol_db_master(y) ma_write_byte(64,y);
-#define get_obj_MA_vol_db_master(o) (o.read(64) & 0xff)>>0 
-#define get_MA_vol_db_master() ( ma_read_byte(64) & 0xff)>>0 
+#define set_obj_MA_vol_db_master(o, y) o.write(64, y);
+#define set_MA_vol_db_master(y) ma_write_byte(64, y);
+#define get_obj_MA_vol_db_master(o) (o.read(64) & 0xff) >> 0
+#define get_MA_vol_db_master() (ma_read_byte(64) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_lsb_master---
-// Master volume lsb 1/4 steps 
+// Master volume lsb 1/4 steps
 #define MA_vol_lsb_master__a 65
 #define MA_vol_lsb_master__len 2
 #define MA_vol_lsb_master__mask 0x03
 #define MA_vol_lsb_master__shift 0x00
 #define MA_vol_lsb_master__reset 0x00
-#define set_obj_MA_vol_lsb_master(o,y) ({ uint8_t __ret = o.read(65); o.write(65,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_vol_lsb_master(y) ({ uint8_t __ret = ma_read_byte(65); ma_write_byte(65,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_vol_lsb_master(o) (o.read(65) & 0x03)>>0 
-#define get_MA_vol_lsb_master() ( ma_read_byte(65) & 0x03)>>0 
+#define set_obj_MA_vol_lsb_master(o, y)              \
+  ({                                                 \
+    uint8_t __ret = o.read(65);                      \
+    o.write(65, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_vol_lsb_master(y)                           \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(65);                      \
+    ma_write_byte(65, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_vol_lsb_master(o) (o.read(65) & 0x03) >> 0
+#define get_MA_vol_lsb_master() (ma_read_byte(65) & 0x03) >> 0
 //------------------------------------------------------------------------------vol_db_ch0---
-// Volume channel 0 
+// Volume channel 0
 #define MA_vol_db_ch0__a 66
 #define MA_vol_db_ch0__len 8
 #define MA_vol_db_ch0__mask 0xff
 #define MA_vol_db_ch0__shift 0x00
 #define MA_vol_db_ch0__reset 0x18
-#define set_obj_MA_vol_db_ch0(o,y) o.write(66,y);
-#define set_MA_vol_db_ch0(y) ma_write_byte(66,y);
-#define get_obj_MA_vol_db_ch0(o) (o.read(66) & 0xff)>>0 
-#define get_MA_vol_db_ch0() ( ma_read_byte(66) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch0(o, y) o.write(66, y);
+#define set_MA_vol_db_ch0(y) ma_write_byte(66, y);
+#define get_obj_MA_vol_db_ch0(o) (o.read(66) & 0xff) >> 0
+#define get_MA_vol_db_ch0() (ma_read_byte(66) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_db_ch1---
-// Volume channel 1 
+// Volume channel 1
 #define MA_vol_db_ch1__a 67
 #define MA_vol_db_ch1__len 8
 #define MA_vol_db_ch1__mask 0xff
 #define MA_vol_db_ch1__shift 0x00
 #define MA_vol_db_ch1__reset 0x18
-#define set_obj_MA_vol_db_ch1(o,y) o.write(67,y);
-#define set_MA_vol_db_ch1(y) ma_write_byte(67,y);
-#define get_obj_MA_vol_db_ch1(o) (o.read(67) & 0xff)>>0 
-#define get_MA_vol_db_ch1() ( ma_read_byte(67) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch1(o, y) o.write(67, y);
+#define set_MA_vol_db_ch1(y) ma_write_byte(67, y);
+#define get_obj_MA_vol_db_ch1(o) (o.read(67) & 0xff) >> 0
+#define get_MA_vol_db_ch1() (ma_read_byte(67) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_db_ch2---
-// Volume channel 2 
+// Volume channel 2
 #define MA_vol_db_ch2__a 68
 #define MA_vol_db_ch2__len 8
 #define MA_vol_db_ch2__mask 0xff
 #define MA_vol_db_ch2__shift 0x00
 #define MA_vol_db_ch2__reset 0x18
-#define set_obj_MA_vol_db_ch2(o,y) o.write(68,y);
-#define set_MA_vol_db_ch2(y) ma_write_byte(68,y);
-#define get_obj_MA_vol_db_ch2(o) (o.read(68) & 0xff)>>0 
-#define get_MA_vol_db_ch2() ( ma_read_byte(68) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch2(o, y) o.write(68, y);
+#define set_MA_vol_db_ch2(y) ma_write_byte(68, y);
+#define get_obj_MA_vol_db_ch2(o) (o.read(68) & 0xff) >> 0
+#define get_MA_vol_db_ch2() (ma_read_byte(68) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_db_ch3---
-// Volume channel 3 
+// Volume channel 3
 #define MA_vol_db_ch3__a 69
 #define MA_vol_db_ch3__len 8
 #define MA_vol_db_ch3__mask 0xff
 #define MA_vol_db_ch3__shift 0x00
 #define MA_vol_db_ch3__reset 0x18
-#define set_obj_MA_vol_db_ch3(o,y) o.write(69,y);
-#define set_MA_vol_db_ch3(y) ma_write_byte(69,y);
-#define get_obj_MA_vol_db_ch3(o) (o.read(69) & 0xff)>>0 
-#define get_MA_vol_db_ch3() ( ma_read_byte(69) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch3(o, y) o.write(69, y);
+#define set_MA_vol_db_ch3(y) ma_write_byte(69, y);
+#define get_obj_MA_vol_db_ch3(o) (o.read(69) & 0xff) >> 0
+#define get_MA_vol_db_ch3() (ma_read_byte(69) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_lsb_ch0---
-// volume channel 1 - 1/4 steps 
+// volume channel 1 - 1/4 steps
 #define MA_vol_lsb_ch0__a 70
 #define MA_vol_lsb_ch0__len 2
 #define MA_vol_lsb_ch0__mask 0x03
 #define MA_vol_lsb_ch0__shift 0x00
 #define MA_vol_lsb_ch0__reset 0x00
-#define set_obj_MA_vol_lsb_ch0(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_vol_lsb_ch0(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_vol_lsb_ch0(o) (o.read(70) & 0x03)>>0 
-#define get_MA_vol_lsb_ch0() ( ma_read_byte(70) & 0x03)>>0 
+#define set_obj_MA_vol_lsb_ch0(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_vol_lsb_ch0(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_vol_lsb_ch0(o) (o.read(70) & 0x03) >> 0
+#define get_MA_vol_lsb_ch0() (ma_read_byte(70) & 0x03) >> 0
 //------------------------------------------------------------------------------vol_lsb_ch1---
-// volume channel 3 - 1/4 steps 
+// volume channel 3 - 1/4 steps
 #define MA_vol_lsb_ch1__a 70
 #define MA_vol_lsb_ch1__len 2
 #define MA_vol_lsb_ch1__mask 0x0c
 #define MA_vol_lsb_ch1__shift 0x02
 #define MA_vol_lsb_ch1__reset 0x00
-#define set_obj_MA_vol_lsb_ch1(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define set_MA_vol_lsb_ch1(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define get_obj_MA_vol_lsb_ch1(o) (o.read(70) & 0x0c)>>2 
-#define get_MA_vol_lsb_ch1() ( ma_read_byte(70) & 0x0c)>>2 
+#define set_obj_MA_vol_lsb_ch1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define set_MA_vol_lsb_ch1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define get_obj_MA_vol_lsb_ch1(o) (o.read(70) & 0x0c) >> 2
+#define get_MA_vol_lsb_ch1() (ma_read_byte(70) & 0x0c) >> 2
 //------------------------------------------------------------------------------vol_lsb_ch2---
-// volume channel 2 - 1/4 steps 
+// volume channel 2 - 1/4 steps
 #define MA_vol_lsb_ch2__a 70
 #define MA_vol_lsb_ch2__len 2
 #define MA_vol_lsb_ch2__mask 0x30
 #define MA_vol_lsb_ch2__shift 0x04
 #define MA_vol_lsb_ch2__reset 0x00
-#define set_obj_MA_vol_lsb_ch2(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_vol_lsb_ch2(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_vol_lsb_ch2(o) (o.read(70) & 0x30)>>4 
-#define get_MA_vol_lsb_ch2() ( ma_read_byte(70) & 0x30)>>4 
+#define set_obj_MA_vol_lsb_ch2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_vol_lsb_ch2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_vol_lsb_ch2(o) (o.read(70) & 0x30) >> 4
+#define get_MA_vol_lsb_ch2() (ma_read_byte(70) & 0x30) >> 4
 //------------------------------------------------------------------------------vol_lsb_ch3---
-// volume channel 3 - 1/4 steps 
+// volume channel 3 - 1/4 steps
 #define MA_vol_lsb_ch3__a 70
 #define MA_vol_lsb_ch3__len 2
 #define MA_vol_lsb_ch3__mask 0xc0
 #define MA_vol_lsb_ch3__shift 0x06
 #define MA_vol_lsb_ch3__reset 0x00
-#define set_obj_MA_vol_lsb_ch3(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define set_MA_vol_lsb_ch3(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define get_obj_MA_vol_lsb_ch3(o) (o.read(70) & 0xc0)>>6 
-#define get_MA_vol_lsb_ch3() ( ma_read_byte(70) & 0xc0)>>6 
+#define set_obj_MA_vol_lsb_ch3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define set_MA_vol_lsb_ch3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define get_obj_MA_vol_lsb_ch3(o) (o.read(70) & 0xc0) >> 6
+#define get_MA_vol_lsb_ch3() (ma_read_byte(70) & 0xc0) >> 6
 //------------------------------------------------------------------------------thr_db_ch0---
-// thr_db channel 0 
+// thr_db channel 0
 #define MA_thr_db_ch0__a 71
 #define MA_thr_db_ch0__len 8
 #define MA_thr_db_ch0__mask 0xff
 #define MA_thr_db_ch0__shift 0x00
 #define MA_thr_db_ch0__reset 0x18
-#define set_obj_MA_thr_db_ch0(o,y) o.write(71,y);
-#define set_MA_thr_db_ch0(y) ma_write_byte(71,y);
-#define get_obj_MA_thr_db_ch0(o) (o.read(71) & 0xff)>>0 
-#define get_MA_thr_db_ch0() ( ma_read_byte(71) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch0(o, y) o.write(71, y);
+#define set_MA_thr_db_ch0(y) ma_write_byte(71, y);
+#define get_obj_MA_thr_db_ch0(o) (o.read(71) & 0xff) >> 0
+#define get_MA_thr_db_ch0() (ma_read_byte(71) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_db_ch1---
-// Thr db ch1 
+// Thr db ch1
 #define MA_thr_db_ch1__a 72
 #define MA_thr_db_ch1__len 8
 #define MA_thr_db_ch1__mask 0xff
 #define MA_thr_db_ch1__shift 0x00
 #define MA_thr_db_ch1__reset 0x18
-#define set_obj_MA_thr_db_ch1(o,y) o.write(72,y);
-#define set_MA_thr_db_ch1(y) ma_write_byte(72,y);
-#define get_obj_MA_thr_db_ch1(o) (o.read(72) & 0xff)>>0 
-#define get_MA_thr_db_ch1() ( ma_read_byte(72) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch1(o, y) o.write(72, y);
+#define set_MA_thr_db_ch1(y) ma_write_byte(72, y);
+#define get_obj_MA_thr_db_ch1(o) (o.read(72) & 0xff) >> 0
+#define get_MA_thr_db_ch1() (ma_read_byte(72) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_db_ch2---
-// thr db ch2 
+// thr db ch2
 #define MA_thr_db_ch2__a 73
 #define MA_thr_db_ch2__len 8
 #define MA_thr_db_ch2__mask 0xff
 #define MA_thr_db_ch2__shift 0x00
 #define MA_thr_db_ch2__reset 0x18
-#define set_obj_MA_thr_db_ch2(o,y) o.write(73,y);
-#define set_MA_thr_db_ch2(y) ma_write_byte(73,y);
-#define get_obj_MA_thr_db_ch2(o) (o.read(73) & 0xff)>>0 
-#define get_MA_thr_db_ch2() ( ma_read_byte(73) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch2(o, y) o.write(73, y);
+#define set_MA_thr_db_ch2(y) ma_write_byte(73, y);
+#define get_obj_MA_thr_db_ch2(o) (o.read(73) & 0xff) >> 0
+#define get_MA_thr_db_ch2() (ma_read_byte(73) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_db_ch3---
-// Threshold db ch3   
+// Threshold db ch3
 #define MA_thr_db_ch3__a 74
 #define MA_thr_db_ch3__len 8
 #define MA_thr_db_ch3__mask 0xff
 #define MA_thr_db_ch3__shift 0x00
 #define MA_thr_db_ch3__reset 0x18
-#define set_obj_MA_thr_db_ch3(o,y) o.write(74,y);
-#define set_MA_thr_db_ch3(y) ma_write_byte(74,y);
-#define get_obj_MA_thr_db_ch3(o) (o.read(74) & 0xff)>>0 
-#define get_MA_thr_db_ch3() ( ma_read_byte(74) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch3(o, y) o.write(74, y);
+#define set_MA_thr_db_ch3(y) ma_write_byte(74, y);
+#define get_obj_MA_thr_db_ch3(o) (o.read(74) & 0xff) >> 0
+#define get_MA_thr_db_ch3() (ma_read_byte(74) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_lsb_ch0---
-// Thr lsb ch0 
+// Thr lsb ch0
 #define MA_thr_lsb_ch0__a 75
 #define MA_thr_lsb_ch0__len 2
 #define MA_thr_lsb_ch0__mask 0x03
 #define MA_thr_lsb_ch0__shift 0x00
 #define MA_thr_lsb_ch0__reset 0x00
-#define set_obj_MA_thr_lsb_ch0(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_thr_lsb_ch0(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_thr_lsb_ch0(o) (o.read(75) & 0x03)>>0 
-#define get_MA_thr_lsb_ch0() ( ma_read_byte(75) & 0x03)>>0 
+#define set_obj_MA_thr_lsb_ch0(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_thr_lsb_ch0(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_thr_lsb_ch0(o) (o.read(75) & 0x03) >> 0
+#define get_MA_thr_lsb_ch0() (ma_read_byte(75) & 0x03) >> 0
 //------------------------------------------------------------------------------thr_lsb_ch1---
-// thr lsb ch1 
+// thr lsb ch1
 #define MA_thr_lsb_ch1__a 75
 #define MA_thr_lsb_ch1__len 2
 #define MA_thr_lsb_ch1__mask 0x0c
 #define MA_thr_lsb_ch1__shift 0x02
 #define MA_thr_lsb_ch1__reset 0x00
-#define set_obj_MA_thr_lsb_ch1(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define set_MA_thr_lsb_ch1(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define get_obj_MA_thr_lsb_ch1(o) (o.read(75) & 0x0c)>>2 
-#define get_MA_thr_lsb_ch1() ( ma_read_byte(75) & 0x0c)>>2 
+#define set_obj_MA_thr_lsb_ch1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define set_MA_thr_lsb_ch1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define get_obj_MA_thr_lsb_ch1(o) (o.read(75) & 0x0c) >> 2
+#define get_MA_thr_lsb_ch1() (ma_read_byte(75) & 0x0c) >> 2
 //------------------------------------------------------------------------------thr_lsb_ch2---
-// thr lsb ch2 1/4 db step 
+// thr lsb ch2 1/4 db step
 #define MA_thr_lsb_ch2__a 75
 #define MA_thr_lsb_ch2__len 2
 #define MA_thr_lsb_ch2__mask 0x30
 #define MA_thr_lsb_ch2__shift 0x04
 #define MA_thr_lsb_ch2__reset 0x00
-#define set_obj_MA_thr_lsb_ch2(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_thr_lsb_ch2(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_thr_lsb_ch2(o) (o.read(75) & 0x30)>>4 
-#define get_MA_thr_lsb_ch2() ( ma_read_byte(75) & 0x30)>>4 
+#define set_obj_MA_thr_lsb_ch2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_thr_lsb_ch2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_thr_lsb_ch2(o) (o.read(75) & 0x30) >> 4
+#define get_MA_thr_lsb_ch2() (ma_read_byte(75) & 0x30) >> 4
 //------------------------------------------------------------------------------thr_lsb_ch3---
-// threshold lsb ch3 
+// threshold lsb ch3
 #define MA_thr_lsb_ch3__a 75
 #define MA_thr_lsb_ch3__len 2
 #define MA_thr_lsb_ch3__mask 0xc0
 #define MA_thr_lsb_ch3__shift 0x06
 #define MA_thr_lsb_ch3__reset 0x00
-#define set_obj_MA_thr_lsb_ch3(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define set_MA_thr_lsb_ch3(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define get_obj_MA_thr_lsb_ch3(o) (o.read(75) & 0xc0)>>6 
-#define get_MA_thr_lsb_ch3() ( ma_read_byte(75) & 0xc0)>>6 
+#define set_obj_MA_thr_lsb_ch3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define set_MA_thr_lsb_ch3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define get_obj_MA_thr_lsb_ch3(o) (o.read(75) & 0xc0) >> 6
+#define get_MA_thr_lsb_ch3() (ma_read_byte(75) & 0xc0) >> 6
 //------------------------------------------------------------------------------dcu_mon0.PM_mon---
-// Power mode monitor channel 0 
+// Power mode monitor channel 0
 #define MA_dcu_mon0__PM_mon__a 96
 #define MA_dcu_mon0__PM_mon__len 2
 #define MA_dcu_mon0__PM_mon__mask 0x03
 #define MA_dcu_mon0__PM_mon__shift 0x00
 #define MA_dcu_mon0__PM_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__PM_mon(o,y) ({ uint8_t __ret = o.read(96); o.write(96,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_dcu_mon0__PM_mon(y) ({ uint8_t __ret = ma_read_byte(96); ma_write_byte(96,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_dcu_mon0__PM_mon(o) (o.read(96) & 0x03)>>0 
-#define get_MA_dcu_mon0__PM_mon() ( ma_read_byte(96) & 0x03)>>0 
+#define set_obj_MA_dcu_mon0__PM_mon(o, y)            \
+  ({                                                 \
+    uint8_t __ret = o.read(96);                      \
+    o.write(96, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_dcu_mon0__PM_mon(y)                         \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(96);                      \
+    ma_write_byte(96, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_dcu_mon0__PM_mon(o) (o.read(96) & 0x03) >> 0
+#define get_MA_dcu_mon0__PM_mon() (ma_read_byte(96) & 0x03) >> 0
 //------------------------------------------------------------------------------dcu_mon0.freqMode_mon---
-// Frequence mode monitor channel 0 
+// Frequence mode monitor channel 0
 #define MA_dcu_mon0__freqMode_mon__a 96
 #define MA_dcu_mon0__freqMode_mon__len 3
 #define MA_dcu_mon0__freqMode_mon__mask 0x70
 #define MA_dcu_mon0__freqMode_mon__shift 0x04
 #define MA_dcu_mon0__freqMode_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__freqMode_mon(o,y) ({ uint8_t __ret = o.read(96); o.write(96,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define set_MA_dcu_mon0__freqMode_mon(y) ({ uint8_t __ret = ma_read_byte(96); ma_write_byte(96,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define get_obj_MA_dcu_mon0__freqMode_mon(o) (o.read(96) & 0x70)>>4 
-#define get_MA_dcu_mon0__freqMode_mon() ( ma_read_byte(96) & 0x70)>>4 
+#define set_obj_MA_dcu_mon0__freqMode_mon(o, y)      \
+  ({                                                 \
+    uint8_t __ret = o.read(96);                      \
+    o.write(96, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define set_MA_dcu_mon0__freqMode_mon(y)                   \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(96);                      \
+    ma_write_byte(96, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define get_obj_MA_dcu_mon0__freqMode_mon(o) (o.read(96) & 0x70) >> 4
+#define get_MA_dcu_mon0__freqMode_mon() (ma_read_byte(96) & 0x70) >> 4
 //------------------------------------------------------------------------------dcu_mon0.pps_passed---
-// DCU0 PPS completion indicator 
+// DCU0 PPS completion indicator
 #define MA_dcu_mon0__pps_passed__a 96
 #define MA_dcu_mon0__pps_passed__len 1
 #define MA_dcu_mon0__pps_passed__mask 0x80
 #define MA_dcu_mon0__pps_passed__shift 0x07
 #define MA_dcu_mon0__pps_passed__reset 0x00
-#define set_obj_MA_dcu_mon0__pps_passed(o,y) ({ uint8_t __ret = o.read(96); o.write(96,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_dcu_mon0__pps_passed(y) ({ uint8_t __ret = ma_read_byte(96); ma_write_byte(96,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_dcu_mon0__pps_passed(o) (o.read(96) & 0x80)>>7 
-#define get_MA_dcu_mon0__pps_passed() ( ma_read_byte(96) & 0x80)>>7 
+#define set_obj_MA_dcu_mon0__pps_passed(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(96);                      \
+    o.write(96, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_dcu_mon0__pps_passed(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(96);                      \
+    ma_write_byte(96, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_dcu_mon0__pps_passed(o) (o.read(96) & 0x80) >> 7
+#define get_MA_dcu_mon0__pps_passed() (ma_read_byte(96) & 0x80) >> 7
 //------------------------------------------------------------------------------dcu_mon0.OCP_mon---
-// OCP Monitor channel 0 
+// OCP Monitor channel 0
 #define MA_dcu_mon0__OCP_mon__a 97
 #define MA_dcu_mon0__OCP_mon__len 1
 #define MA_dcu_mon0__OCP_mon__mask 0x01
 #define MA_dcu_mon0__OCP_mon__shift 0x00
 #define MA_dcu_mon0__OCP_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__OCP_mon(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_dcu_mon0__OCP_mon(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_dcu_mon0__OCP_mon(o) (o.read(97) & 0x01)>>0 
-#define get_MA_dcu_mon0__OCP_mon() ( ma_read_byte(97) & 0x01)>>0 
+#define set_obj_MA_dcu_mon0__OCP_mon(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_dcu_mon0__OCP_mon(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_dcu_mon0__OCP_mon(o) (o.read(97) & 0x01) >> 0
+#define get_MA_dcu_mon0__OCP_mon() (ma_read_byte(97) & 0x01) >> 0
 //------------------------------------------------------------------------------dcu_mon0.Vcfly1_ok---
-// Cfly1 protection monitor channel 0. 
+// Cfly1 protection monitor channel 0.
 #define MA_dcu_mon0__Vcfly1_ok__a 97
 #define MA_dcu_mon0__Vcfly1_ok__len 1
 #define MA_dcu_mon0__Vcfly1_ok__mask 0x02
 #define MA_dcu_mon0__Vcfly1_ok__shift 0x01
 #define MA_dcu_mon0__Vcfly1_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__Vcfly1_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_dcu_mon0__Vcfly1_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_dcu_mon0__Vcfly1_ok(o) (o.read(97) & 0x02)>>1 
-#define get_MA_dcu_mon0__Vcfly1_ok() ( ma_read_byte(97) & 0x02)>>1 
+#define set_obj_MA_dcu_mon0__Vcfly1_ok(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_dcu_mon0__Vcfly1_ok(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_dcu_mon0__Vcfly1_ok(o) (o.read(97) & 0x02) >> 1
+#define get_MA_dcu_mon0__Vcfly1_ok() (ma_read_byte(97) & 0x02) >> 1
 //------------------------------------------------------------------------------dcu_mon0.Vcfly2_ok---
-// Cfly2 protection monitor channel 0. 
+// Cfly2 protection monitor channel 0.
 #define MA_dcu_mon0__Vcfly2_ok__a 97
 #define MA_dcu_mon0__Vcfly2_ok__len 1
 #define MA_dcu_mon0__Vcfly2_ok__mask 0x04
 #define MA_dcu_mon0__Vcfly2_ok__shift 0x02
 #define MA_dcu_mon0__Vcfly2_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__Vcfly2_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_dcu_mon0__Vcfly2_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_dcu_mon0__Vcfly2_ok(o) (o.read(97) & 0x04)>>2 
-#define get_MA_dcu_mon0__Vcfly2_ok() ( ma_read_byte(97) & 0x04)>>2 
+#define set_obj_MA_dcu_mon0__Vcfly2_ok(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_dcu_mon0__Vcfly2_ok(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_dcu_mon0__Vcfly2_ok(o) (o.read(97) & 0x04) >> 2
+#define get_MA_dcu_mon0__Vcfly2_ok() (ma_read_byte(97) & 0x04) >> 2
 //------------------------------------------------------------------------------dcu_mon0.pvdd_ok---
-// DCU0 PVDD monitor 
+// DCU0 PVDD monitor
 #define MA_dcu_mon0__pvdd_ok__a 97
 #define MA_dcu_mon0__pvdd_ok__len 1
 #define MA_dcu_mon0__pvdd_ok__mask 0x08
 #define MA_dcu_mon0__pvdd_ok__shift 0x03
 #define MA_dcu_mon0__pvdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__pvdd_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define set_MA_dcu_mon0__pvdd_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define get_obj_MA_dcu_mon0__pvdd_ok(o) (o.read(97) & 0x08)>>3 
-#define get_MA_dcu_mon0__pvdd_ok() ( ma_read_byte(97) & 0x08)>>3 
+#define set_obj_MA_dcu_mon0__pvdd_ok(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define set_MA_dcu_mon0__pvdd_ok(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define get_obj_MA_dcu_mon0__pvdd_ok(o) (o.read(97) & 0x08) >> 3
+#define get_MA_dcu_mon0__pvdd_ok() (ma_read_byte(97) & 0x08) >> 3
 //------------------------------------------------------------------------------dcu_mon0.vdd_ok---
-// DCU0 VDD monitor 
+// DCU0 VDD monitor
 #define MA_dcu_mon0__vdd_ok__a 97
 #define MA_dcu_mon0__vdd_ok__len 1
 #define MA_dcu_mon0__vdd_ok__mask 0x10
 #define MA_dcu_mon0__vdd_ok__shift 0x04
 #define MA_dcu_mon0__vdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__vdd_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define set_MA_dcu_mon0__vdd_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define get_obj_MA_dcu_mon0__vdd_ok(o) (o.read(97) & 0x10)>>4 
-#define get_MA_dcu_mon0__vdd_ok() ( ma_read_byte(97) & 0x10)>>4 
+#define set_obj_MA_dcu_mon0__vdd_ok(o, y)            \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define set_MA_dcu_mon0__vdd_ok(y)                         \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define get_obj_MA_dcu_mon0__vdd_ok(o) (o.read(97) & 0x10) >> 4
+#define get_MA_dcu_mon0__vdd_ok() (ma_read_byte(97) & 0x10) >> 4
 //------------------------------------------------------------------------------dcu_mon0.mute---
-// DCU0 mute monitor 
+// DCU0 mute monitor
 #define MA_dcu_mon0__mute__a 97
 #define MA_dcu_mon0__mute__len 1
 #define MA_dcu_mon0__mute__mask 0x20
 #define MA_dcu_mon0__mute__shift 0x05
 #define MA_dcu_mon0__mute__reset 0x00
-#define set_obj_MA_dcu_mon0__mute(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_dcu_mon0__mute(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_dcu_mon0__mute(o) (o.read(97) & 0x20)>>5 
-#define get_MA_dcu_mon0__mute() ( ma_read_byte(97) & 0x20)>>5 
+#define set_obj_MA_dcu_mon0__mute(o, y)              \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_dcu_mon0__mute(y)                           \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_dcu_mon0__mute(o) (o.read(97) & 0x20) >> 5
+#define get_MA_dcu_mon0__mute() (ma_read_byte(97) & 0x20) >> 5
 //------------------------------------------------------------------------------dcu_mon0.M_mon---
-// M sense monitor channel 0 
+// M sense monitor channel 0
 #define MA_dcu_mon0__M_mon__a 98
 #define MA_dcu_mon0__M_mon__len 8
 #define MA_dcu_mon0__M_mon__mask 0xff
 #define MA_dcu_mon0__M_mon__shift 0x00
 #define MA_dcu_mon0__M_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__M_mon(o,y) o.write(98,y);
-#define set_MA_dcu_mon0__M_mon(y) ma_write_byte(98,y);
-#define get_obj_MA_dcu_mon0__M_mon(o) (o.read(98) & 0xff)>>0 
-#define get_MA_dcu_mon0__M_mon() ( ma_read_byte(98) & 0xff)>>0 
+#define set_obj_MA_dcu_mon0__M_mon(o, y) o.write(98, y);
+#define set_MA_dcu_mon0__M_mon(y) ma_write_byte(98, y);
+#define get_obj_MA_dcu_mon0__M_mon(o) (o.read(98) & 0xff) >> 0
+#define get_MA_dcu_mon0__M_mon() (ma_read_byte(98) & 0xff) >> 0
 //------------------------------------------------------------------------------dcu_mon1.PM_mon---
-// Power mode monitor channel 1 
+// Power mode monitor channel 1
 #define MA_dcu_mon1__PM_mon__a 100
 #define MA_dcu_mon1__PM_mon__len 2
 #define MA_dcu_mon1__PM_mon__mask 0x03
 #define MA_dcu_mon1__PM_mon__shift 0x00
 #define MA_dcu_mon1__PM_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__PM_mon(o,y) ({ uint8_t __ret = o.read(100); o.write(100,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_dcu_mon1__PM_mon(y) ({ uint8_t __ret = ma_read_byte(100); ma_write_byte(100,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_dcu_mon1__PM_mon(o) (o.read(100) & 0x03)>>0 
-#define get_MA_dcu_mon1__PM_mon() ( ma_read_byte(100) & 0x03)>>0 
+#define set_obj_MA_dcu_mon1__PM_mon(o, y)             \
+  ({                                                  \
+    uint8_t __ret = o.read(100);                      \
+    o.write(100, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_dcu_mon1__PM_mon(y)                          \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(100);                      \
+    ma_write_byte(100, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_dcu_mon1__PM_mon(o) (o.read(100) & 0x03) >> 0
+#define get_MA_dcu_mon1__PM_mon() (ma_read_byte(100) & 0x03) >> 0
 //------------------------------------------------------------------------------dcu_mon1.freqMode_mon---
-// Frequence mode monitor channel 1 
+// Frequence mode monitor channel 1
 #define MA_dcu_mon1__freqMode_mon__a 100
 #define MA_dcu_mon1__freqMode_mon__len 3
 #define MA_dcu_mon1__freqMode_mon__mask 0x70
 #define MA_dcu_mon1__freqMode_mon__shift 0x04
 #define MA_dcu_mon1__freqMode_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__freqMode_mon(o,y) ({ uint8_t __ret = o.read(100); o.write(100,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define set_MA_dcu_mon1__freqMode_mon(y) ({ uint8_t __ret = ma_read_byte(100); ma_write_byte(100,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define get_obj_MA_dcu_mon1__freqMode_mon(o) (o.read(100) & 0x70)>>4 
-#define get_MA_dcu_mon1__freqMode_mon() ( ma_read_byte(100) & 0x70)>>4 
+#define set_obj_MA_dcu_mon1__freqMode_mon(o, y)       \
+  ({                                                  \
+    uint8_t __ret = o.read(100);                      \
+    o.write(100, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define set_MA_dcu_mon1__freqMode_mon(y)                    \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(100);                      \
+    ma_write_byte(100, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define get_obj_MA_dcu_mon1__freqMode_mon(o) (o.read(100) & 0x70) >> 4
+#define get_MA_dcu_mon1__freqMode_mon() (ma_read_byte(100) & 0x70) >> 4
 //------------------------------------------------------------------------------dcu_mon1.pps_passed---
-// DCU1 PPS completion indicator 
+// DCU1 PPS completion indicator
 #define MA_dcu_mon1__pps_passed__a 100
 #define MA_dcu_mon1__pps_passed__len 1
 #define MA_dcu_mon1__pps_passed__mask 0x80
 #define MA_dcu_mon1__pps_passed__shift 0x07
 #define MA_dcu_mon1__pps_passed__reset 0x00
-#define set_obj_MA_dcu_mon1__pps_passed(o,y) ({ uint8_t __ret = o.read(100); o.write(100,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_dcu_mon1__pps_passed(y) ({ uint8_t __ret = ma_read_byte(100); ma_write_byte(100,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_dcu_mon1__pps_passed(o) (o.read(100) & 0x80)>>7 
-#define get_MA_dcu_mon1__pps_passed() ( ma_read_byte(100) & 0x80)>>7 
+#define set_obj_MA_dcu_mon1__pps_passed(o, y)         \
+  ({                                                  \
+    uint8_t __ret = o.read(100);                      \
+    o.write(100, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_dcu_mon1__pps_passed(y)                      \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(100);                      \
+    ma_write_byte(100, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_dcu_mon1__pps_passed(o) (o.read(100) & 0x80) >> 7
+#define get_MA_dcu_mon1__pps_passed() (ma_read_byte(100) & 0x80) >> 7
 //------------------------------------------------------------------------------dcu_mon1.OCP_mon---
-// OCP Monitor channel 1 
+// OCP Monitor channel 1
 #define MA_dcu_mon1__OCP_mon__a 101
 #define MA_dcu_mon1__OCP_mon__len 1
 #define MA_dcu_mon1__OCP_mon__mask 0x01
 #define MA_dcu_mon1__OCP_mon__shift 0x00
 #define MA_dcu_mon1__OCP_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__OCP_mon(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_dcu_mon1__OCP_mon(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_dcu_mon1__OCP_mon(o) (o.read(101) & 0x01)>>0 
-#define get_MA_dcu_mon1__OCP_mon() ( ma_read_byte(101) & 0x01)>>0 
+#define set_obj_MA_dcu_mon1__OCP_mon(o, y)            \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_dcu_mon1__OCP_mon(y)                         \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_dcu_mon1__OCP_mon(o) (o.read(101) & 0x01) >> 0
+#define get_MA_dcu_mon1__OCP_mon() (ma_read_byte(101) & 0x01) >> 0
 //------------------------------------------------------------------------------dcu_mon1.Vcfly1_ok---
-// Cfly1 protcetion monitor channel 1 
+// Cfly1 protcetion monitor channel 1
 #define MA_dcu_mon1__Vcfly1_ok__a 101
 #define MA_dcu_mon1__Vcfly1_ok__len 1
 #define MA_dcu_mon1__Vcfly1_ok__mask 0x02
 #define MA_dcu_mon1__Vcfly1_ok__shift 0x01
 #define MA_dcu_mon1__Vcfly1_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__Vcfly1_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_dcu_mon1__Vcfly1_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_dcu_mon1__Vcfly1_ok(o) (o.read(101) & 0x02)>>1 
-#define get_MA_dcu_mon1__Vcfly1_ok() ( ma_read_byte(101) & 0x02)>>1 
+#define set_obj_MA_dcu_mon1__Vcfly1_ok(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_dcu_mon1__Vcfly1_ok(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_dcu_mon1__Vcfly1_ok(o) (o.read(101) & 0x02) >> 1
+#define get_MA_dcu_mon1__Vcfly1_ok() (ma_read_byte(101) & 0x02) >> 1
 //------------------------------------------------------------------------------dcu_mon1.Vcfly2_ok---
-// Cfly2 protection monitor channel 1 
+// Cfly2 protection monitor channel 1
 #define MA_dcu_mon1__Vcfly2_ok__a 101
 #define MA_dcu_mon1__Vcfly2_ok__len 1
 #define MA_dcu_mon1__Vcfly2_ok__mask 0x04
 #define MA_dcu_mon1__Vcfly2_ok__shift 0x02
 #define MA_dcu_mon1__Vcfly2_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__Vcfly2_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_dcu_mon1__Vcfly2_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_dcu_mon1__Vcfly2_ok(o) (o.read(101) & 0x04)>>2 
-#define get_MA_dcu_mon1__Vcfly2_ok() ( ma_read_byte(101) & 0x04)>>2 
+#define set_obj_MA_dcu_mon1__Vcfly2_ok(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_dcu_mon1__Vcfly2_ok(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_dcu_mon1__Vcfly2_ok(o) (o.read(101) & 0x04) >> 2
+#define get_MA_dcu_mon1__Vcfly2_ok() (ma_read_byte(101) & 0x04) >> 2
 //------------------------------------------------------------------------------dcu_mon1.pvdd_ok---
-// DCU1 PVDD monitor 
+// DCU1 PVDD monitor
 #define MA_dcu_mon1__pvdd_ok__a 101
 #define MA_dcu_mon1__pvdd_ok__len 1
 #define MA_dcu_mon1__pvdd_ok__mask 0x08
 #define MA_dcu_mon1__pvdd_ok__shift 0x03
 #define MA_dcu_mon1__pvdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__pvdd_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define set_MA_dcu_mon1__pvdd_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define get_obj_MA_dcu_mon1__pvdd_ok(o) (o.read(101) & 0x08)>>3 
-#define get_MA_dcu_mon1__pvdd_ok() ( ma_read_byte(101) & 0x08)>>3 
+#define set_obj_MA_dcu_mon1__pvdd_ok(o, y)            \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define set_MA_dcu_mon1__pvdd_ok(y)                         \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define get_obj_MA_dcu_mon1__pvdd_ok(o) (o.read(101) & 0x08) >> 3
+#define get_MA_dcu_mon1__pvdd_ok() (ma_read_byte(101) & 0x08) >> 3
 //------------------------------------------------------------------------------dcu_mon1.vdd_ok---
-// DCU1 VDD monitor 
+// DCU1 VDD monitor
 #define MA_dcu_mon1__vdd_ok__a 101
 #define MA_dcu_mon1__vdd_ok__len 1
 #define MA_dcu_mon1__vdd_ok__mask 0x10
 #define MA_dcu_mon1__vdd_ok__shift 0x04
 #define MA_dcu_mon1__vdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__vdd_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define set_MA_dcu_mon1__vdd_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define get_obj_MA_dcu_mon1__vdd_ok(o) (o.read(101) & 0x10)>>4 
-#define get_MA_dcu_mon1__vdd_ok() ( ma_read_byte(101) & 0x10)>>4 
+#define set_obj_MA_dcu_mon1__vdd_ok(o, y)             \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define set_MA_dcu_mon1__vdd_ok(y)                          \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define get_obj_MA_dcu_mon1__vdd_ok(o) (o.read(101) & 0x10) >> 4
+#define get_MA_dcu_mon1__vdd_ok() (ma_read_byte(101) & 0x10) >> 4
 //------------------------------------------------------------------------------dcu_mon1.mute---
-// DCU1 mute monitor 
+// DCU1 mute monitor
 #define MA_dcu_mon1__mute__a 101
 #define MA_dcu_mon1__mute__len 1
 #define MA_dcu_mon1__mute__mask 0x20
 #define MA_dcu_mon1__mute__shift 0x05
 #define MA_dcu_mon1__mute__reset 0x00
-#define set_obj_MA_dcu_mon1__mute(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_dcu_mon1__mute(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_dcu_mon1__mute(o) (o.read(101) & 0x20)>>5 
-#define get_MA_dcu_mon1__mute() ( ma_read_byte(101) & 0x20)>>5 
+#define set_obj_MA_dcu_mon1__mute(o, y)               \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_dcu_mon1__mute(y)                            \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_dcu_mon1__mute(o) (o.read(101) & 0x20) >> 5
+#define get_MA_dcu_mon1__mute() (ma_read_byte(101) & 0x20) >> 5
 //------------------------------------------------------------------------------dcu_mon1.M_mon---
-// M sense monitor channel 1 
+// M sense monitor channel 1
 #define MA_dcu_mon1__M_mon__a 102
 #define MA_dcu_mon1__M_mon__len 8
 #define MA_dcu_mon1__M_mon__mask 0xff
 #define MA_dcu_mon1__M_mon__shift 0x00
 #define MA_dcu_mon1__M_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__M_mon(o,y) o.write(102,y);
-#define set_MA_dcu_mon1__M_mon(y) ma_write_byte(102,y);
-#define get_obj_MA_dcu_mon1__M_mon(o) (o.read(102) & 0xff)>>0 
-#define get_MA_dcu_mon1__M_mon() ( ma_read_byte(102) & 0xff)>>0 
+#define set_obj_MA_dcu_mon1__M_mon(o, y) o.write(102, y);
+#define set_MA_dcu_mon1__M_mon(y) ma_write_byte(102, y);
+#define get_obj_MA_dcu_mon1__M_mon(o) (o.read(102) & 0xff) >> 0
+#define get_MA_dcu_mon1__M_mon() (ma_read_byte(102) & 0xff) >> 0
 //------------------------------------------------------------------------------dcu_mon0.sw_enable---
-// DCU0 Switch enable monitor 
+// DCU0 Switch enable monitor
 #define MA_dcu_mon0__sw_enable__a 104
 #define MA_dcu_mon0__sw_enable__len 1
 #define MA_dcu_mon0__sw_enable__mask 0x40
 #define MA_dcu_mon0__sw_enable__shift 0x06
 #define MA_dcu_mon0__sw_enable__reset 0x00
-#define set_obj_MA_dcu_mon0__sw_enable(o,y) ({ uint8_t __ret = o.read(104); o.write(104,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_dcu_mon0__sw_enable(y) ({ uint8_t __ret = ma_read_byte(104); ma_write_byte(104,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_dcu_mon0__sw_enable(o) (o.read(104) & 0x40)>>6 
-#define get_MA_dcu_mon0__sw_enable() ( ma_read_byte(104) & 0x40)>>6 
+#define set_obj_MA_dcu_mon0__sw_enable(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(104);                      \
+    o.write(104, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_dcu_mon0__sw_enable(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(104);                      \
+    ma_write_byte(104, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_dcu_mon0__sw_enable(o) (o.read(104) & 0x40) >> 6
+#define get_MA_dcu_mon0__sw_enable() (ma_read_byte(104) & 0x40) >> 6
 //------------------------------------------------------------------------------dcu_mon1.sw_enable---
-// DCU1 Switch enable monitor 
+// DCU1 Switch enable monitor
 #define MA_dcu_mon1__sw_enable__a 104
 #define MA_dcu_mon1__sw_enable__len 1
 #define MA_dcu_mon1__sw_enable__mask 0x80
 #define MA_dcu_mon1__sw_enable__shift 0x07
 #define MA_dcu_mon1__sw_enable__reset 0x00
-#define set_obj_MA_dcu_mon1__sw_enable(o,y) ({ uint8_t __ret = o.read(104); o.write(104,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_dcu_mon1__sw_enable(y) ({ uint8_t __ret = ma_read_byte(104); ma_write_byte(104,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_dcu_mon1__sw_enable(o) (o.read(104) & 0x80)>>7 
-#define get_MA_dcu_mon1__sw_enable() ( ma_read_byte(104) & 0x80)>>7 
+#define set_obj_MA_dcu_mon1__sw_enable(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(104);                      \
+    o.write(104, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_dcu_mon1__sw_enable(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(104);                      \
+    ma_write_byte(104, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_dcu_mon1__sw_enable(o) (o.read(104) & 0x80) >> 7
+#define get_MA_dcu_mon1__sw_enable() (ma_read_byte(104) & 0x80) >> 7
 //------------------------------------------------------------------------------hvboot0_ok_mon---
-// HVboot0_ok for test/debug 
+// HVboot0_ok for test/debug
 #define MA_hvboot0_ok_mon__a 105
 #define MA_hvboot0_ok_mon__len 1
 #define MA_hvboot0_ok_mon__mask 0x40
 #define MA_hvboot0_ok_mon__shift 0x06
 #define MA_hvboot0_ok_mon__reset 0x00
-#define set_obj_MA_hvboot0_ok_mon(o,y) ({ uint8_t __ret = o.read(105); o.write(105,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_hvboot0_ok_mon(y) ({ uint8_t __ret = ma_read_byte(105); ma_write_byte(105,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_hvboot0_ok_mon(o) (o.read(105) & 0x40)>>6 
-#define get_MA_hvboot0_ok_mon() ( ma_read_byte(105) & 0x40)>>6 
+#define set_obj_MA_hvboot0_ok_mon(o, y)               \
+  ({                                                  \
+    uint8_t __ret = o.read(105);                      \
+    o.write(105, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_hvboot0_ok_mon(y)                            \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(105);                      \
+    ma_write_byte(105, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_hvboot0_ok_mon(o) (o.read(105) & 0x40) >> 6
+#define get_MA_hvboot0_ok_mon() (ma_read_byte(105) & 0x40) >> 6
 //------------------------------------------------------------------------------hvboot1_ok_mon---
-// HVboot1_ok for test/debug 
+// HVboot1_ok for test/debug
 #define MA_hvboot1_ok_mon__a 105
 #define MA_hvboot1_ok_mon__len 1
 #define MA_hvboot1_ok_mon__mask 0x80
 #define MA_hvboot1_ok_mon__shift 0x07
 #define MA_hvboot1_ok_mon__reset 0x00
-#define set_obj_MA_hvboot1_ok_mon(o,y) ({ uint8_t __ret = o.read(105); o.write(105,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_hvboot1_ok_mon(y) ({ uint8_t __ret = ma_read_byte(105); ma_write_byte(105,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_hvboot1_ok_mon(o) (o.read(105) & 0x80)>>7 
-#define get_MA_hvboot1_ok_mon() ( ma_read_byte(105) & 0x80)>>7 
+#define set_obj_MA_hvboot1_ok_mon(o, y)               \
+  ({                                                  \
+    uint8_t __ret = o.read(105);                      \
+    o.write(105, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_hvboot1_ok_mon(y)                            \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(105);                      \
+    ma_write_byte(105, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_hvboot1_ok_mon(o) (o.read(105) & 0x80) >> 7
+#define get_MA_hvboot1_ok_mon() (ma_read_byte(105) & 0x80) >> 7
 //------------------------------------------------------------------------------error_acc---
-// Accumulated errors, at and after triggering 
+// Accumulated errors, at and after triggering
 #define MA_error_acc__a 109
 #define MA_error_acc__len 8
 #define MA_error_acc__mask 0xff
 #define MA_error_acc__shift 0x00
 #define MA_error_acc__reset 0x00
-#define set_obj_MA_error_acc(o,y) o.write(109,y);
-#define set_MA_error_acc(y) ma_write_byte(109,y);
-#define get_obj_MA_error_acc(o) (o.read(109) & 0xff)>>0 
-#define get_MA_error_acc() ( ma_read_byte(109) & 0xff)>>0 
+#define set_obj_MA_error_acc(o, y) o.write(109, y);
+#define set_MA_error_acc(y) ma_write_byte(109, y);
+#define get_obj_MA_error_acc(o) (o.read(109) & 0xff) >> 0
+#define get_MA_error_acc() (ma_read_byte(109) & 0xff) >> 0
 //------------------------------------------------------------------------------i2s_data_rate---
-// Detected i2s data rate: 00/01/10 = x1/x2/x4 
+// Detected i2s data rate: 00/01/10 = x1/x2/x4
 #define MA_i2s_data_rate__a 116
 #define MA_i2s_data_rate__len 2
 #define MA_i2s_data_rate__mask 0x03
 #define MA_i2s_data_rate__shift 0x00
 #define MA_i2s_data_rate__reset 0x00
-#define set_obj_MA_i2s_data_rate(o,y) ({ uint8_t __ret = o.read(116); o.write(116,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_i2s_data_rate(y) ({ uint8_t __ret = ma_read_byte(116); ma_write_byte(116,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_i2s_data_rate(o) (o.read(116) & 0x03)>>0 
-#define get_MA_i2s_data_rate() ( ma_read_byte(116) & 0x03)>>0 
+#define set_obj_MA_i2s_data_rate(o, y)                \
+  ({                                                  \
+    uint8_t __ret = o.read(116);                      \
+    o.write(116, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_i2s_data_rate(y)                             \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(116);                      \
+    ma_write_byte(116, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_i2s_data_rate(o) (o.read(116) & 0x03) >> 0
+#define get_MA_i2s_data_rate() (ma_read_byte(116) & 0x03) >> 0
 //------------------------------------------------------------------------------audio_in_mode_mon---
-// Audio input mode monitor 
+// Audio input mode monitor
 #define MA_audio_in_mode_mon__a 116
 #define MA_audio_in_mode_mon__len 3
 #define MA_audio_in_mode_mon__mask 0x1c
 #define MA_audio_in_mode_mon__shift 0x02
 #define MA_audio_in_mode_mon__reset 0x00
-#define set_obj_MA_audio_in_mode_mon(o,y) ({ uint8_t __ret = o.read(116); o.write(116,(__ret&0xe3)|((y<<2)&0x1c)); }) 
-#define set_MA_audio_in_mode_mon(y) ({ uint8_t __ret = ma_read_byte(116); ma_write_byte(116,(__ret&0xe3)|((y<<2)&0x1c)); }) 
-#define get_obj_MA_audio_in_mode_mon(o) (o.read(116) & 0x1c)>>2 
-#define get_MA_audio_in_mode_mon() ( ma_read_byte(116) & 0x1c)>>2 
+#define set_obj_MA_audio_in_mode_mon(o, y)            \
+  ({                                                  \
+    uint8_t __ret = o.read(116);                      \
+    o.write(116, (__ret & 0xe3) | ((y << 2) & 0x1c)); \
+  })
+#define set_MA_audio_in_mode_mon(y)                         \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(116);                      \
+    ma_write_byte(116, (__ret & 0xe3) | ((y << 2) & 0x1c)); \
+  })
+#define get_obj_MA_audio_in_mode_mon(o) (o.read(116) & 0x1c) >> 2
+#define get_MA_audio_in_mode_mon() (ma_read_byte(116) & 0x1c) >> 2
 //------------------------------------------------------------------------------msel_mon---
-// MSEL[2:0] monitor register 
+// MSEL[2:0] monitor register
 #define MA_msel_mon__a 117
 #define MA_msel_mon__len 3
 #define MA_msel_mon__mask 0x07
 #define MA_msel_mon__shift 0x00
 #define MA_msel_mon__reset 0x00
-#define set_obj_MA_msel_mon(o,y) ({ uint8_t __ret = o.read(117); o.write(117,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_msel_mon(y) ({ uint8_t __ret = ma_read_byte(117); ma_write_byte(117,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_msel_mon(o) (o.read(117) & 0x07)>>0 
-#define get_MA_msel_mon() ( ma_read_byte(117) & 0x07)>>0 
+#define set_obj_MA_msel_mon(o, y)                     \
+  ({                                                  \
+    uint8_t __ret = o.read(117);                      \
+    o.write(117, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_msel_mon(y)                                  \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(117);                      \
+    ma_write_byte(117, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_msel_mon(o) (o.read(117) & 0x07) >> 0
+#define get_MA_msel_mon() (ma_read_byte(117) & 0x07) >> 0
 //------------------------------------------------------------------------------error---
-// Current error flag monitor reg - for app. ctrl. 
+// Current error flag monitor reg - for app. ctrl.
 #define MA_error__a 124
 #define MA_error__len 8
 #define MA_error__mask 0xff
 #define MA_error__shift 0x00
 #define MA_error__reset 0x00
-#define set_obj_MA_error(o,y) o.write(124,y);
-#define set_MA_error(y) ma_write_byte(124,y);
-#define get_obj_MA_error(o) (o.read(124) & 0xff)>>0 
-#define get_MA_error() ( ma_read_byte(124) & 0xff)>>0 
+#define set_obj_MA_error(o, y) o.write(124, y);
+#define set_MA_error(y) ma_write_byte(124, y);
+#define get_obj_MA_error(o) (o.read(124) & 0xff) >> 0
+#define get_MA_error() (ma_read_byte(124) & 0xff) >> 0
 //------------------------------------------------------------------------------audio_proc_limiter_mon---
-// b7-b4: Channel 3-0 limiter active  
+// b7-b4: Channel 3-0 limiter active
 #define MA_audio_proc_limiter_mon__a 126
 #define MA_audio_proc_limiter_mon__len 4
 #define MA_audio_proc_limiter_mon__mask 0xf0
 #define MA_audio_proc_limiter_mon__shift 0x04
 #define MA_audio_proc_limiter_mon__reset 0x00
-#define set_obj_MA_audio_proc_limiter_mon(o,y) ({ uint8_t __ret = o.read(126); o.write(126,(__ret&0x0f)|((y<<4)&0xf0)); }) 
-#define set_MA_audio_proc_limiter_mon(y) ({ uint8_t __ret = ma_read_byte(126); ma_write_byte(126,(__ret&0x0f)|((y<<4)&0xf0)); }) 
-#define get_obj_MA_audio_proc_limiter_mon(o) (o.read(126) & 0xf0)>>4 
-#define get_MA_audio_proc_limiter_mon() ( ma_read_byte(126) & 0xf0)>>4 
+#define set_obj_MA_audio_proc_limiter_mon(o, y)       \
+  ({                                                  \
+    uint8_t __ret = o.read(126);                      \
+    o.write(126, (__ret & 0x0f) | ((y << 4) & 0xf0)); \
+  })
+#define set_MA_audio_proc_limiter_mon(y)                    \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(126);                      \
+    ma_write_byte(126, (__ret & 0x0f) | ((y << 4) & 0xf0)); \
+  })
+#define get_obj_MA_audio_proc_limiter_mon(o) (o.read(126) & 0xf0) >> 4
+#define get_MA_audio_proc_limiter_mon() (ma_read_byte(126) & 0xf0) >> 4
 //------------------------------------------------------------------------------audio_proc_clip_mon---
-// b3-b0: Channel 3-0 clipping monitor 
+// b3-b0: Channel 3-0 clipping monitor
 #define MA_audio_proc_clip_mon__a 126
 #define MA_audio_proc_clip_mon__len 4
 #define MA_audio_proc_clip_mon__mask 0x0f
 #define MA_audio_proc_clip_mon__shift 0x00
 #define MA_audio_proc_clip_mon__reset 0x00
-#define set_obj_MA_audio_proc_clip_mon(o,y) ({ uint8_t __ret = o.read(126); o.write(126,(__ret&0xf0)|((y<<0)&0x0f)); }) 
-#define set_MA_audio_proc_clip_mon(y) ({ uint8_t __ret = ma_read_byte(126); ma_write_byte(126,(__ret&0xf0)|((y<<0)&0x0f)); }) 
-#define get_obj_MA_audio_proc_clip_mon(o) (o.read(126) & 0x0f)>>0 
-#define get_MA_audio_proc_clip_mon() ( ma_read_byte(126) & 0x0f)>>0 
+#define set_obj_MA_audio_proc_clip_mon(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(126);                      \
+    o.write(126, (__ret & 0xf0) | ((y << 0) & 0x0f)); \
+  })
+#define set_MA_audio_proc_clip_mon(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(126);                      \
+    ma_write_byte(126, (__ret & 0xf0) | ((y << 0) & 0x0f)); \
+  })
+#define get_obj_MA_audio_proc_clip_mon(o) (o.read(126) & 0x0f) >> 0
+#define get_MA_audio_proc_clip_mon() (ma_read_byte(126) & 0x0f) >> 0
 
 //------------------------------------------------------------------------------hw_version---
-// Hardware version ID number 
+// Hardware version ID number
 #define MA_hw_version__a 127
 #define MA_hw_version__len 8
 #define MA_hw_version__mask 0xff
 #define MA_hw_version__shift 0x00
 #define MA_hw_version__reset 0x00
-#define set_obj_MA_hw_version(o,y) o.write(127,y);
-#define set_MA_hw_version(y) ma_write_byte(127,y);
-#define get_obj_MA_hw_version(o) (o.read(127) & 0xff)>>0 
-#define get_MA_hw_version() ( ma_read_byte(127) & 0xff)>>0 
+#define set_obj_MA_hw_version(o, y) o.write(127, y);
+#define set_MA_hw_version(y) ma_write_byte(127, y);
+#define get_obj_MA_hw_version(o) (o.read(127) & 0xff) >> 0
+#define get_MA_hw_version() (ma_read_byte(127) & 0xff) >> 0
 
-
-#endif   /* _MA120X0_H_ */
+#endif /* _MA120X0_H_ */

--- a/components/custom_board/ma120/ma120.c
+++ b/components/custom_board/ma120/ma120.c
@@ -4,51 +4,51 @@
 // Merus Audio - September 2018
 // Written by Joergen Kragh Jakobsen, jkj@myrun.dk
 //
-// Register interface thrugh I2C for MA120 
+// Register interface thrugh I2C for MA120
 //   Support a single amplifier/i2c address
 //
 //
 
-#include <stdio.h>
 #include <stdint.h>
-#include "esp_log.h"
-#include "driver/i2c.h"
-
-#include "board.h"
+#include <stdio.h>
 
 #include "MerusAudio.h"
+#include "board.h"
+#include "driver/i2c.h"
+#include "esp_log.h"
 
 //#include "ma120x0.h"
 //#include "ma120_rev1_all.h"
 
 static const char *TAG = "MA120";
 
-#define MA_ENABLE_IO   CONFIG_MA120_ENABLE_PIN
-#define MA_NMUTE_IO    CONFIG_MA120_NMUTE_PIN
-#define MA_NERR_IO     CONFIG_MERUS_NERR_PIN
-#define MA_NCLIP_IO    CONFIG_MERUS_NCLIP_PIN
+#define MA_ENABLE_IO CONFIG_MA120_ENABLE_PIN
+#define MA_NMUTE_IO CONFIG_MA120_NMUTE_PIN
+#define MA_NERR_IO CONFIG_MERUS_NERR_PIN
+#define MA_NCLIP_IO CONFIG_MERUS_NCLIP_PIN
 
-static const char* I2C_TAG = "i2c";
-#define I2C_CHECK(a, str, ret)  if(!(a)) {                                             \
-        ESP_LOGE(I2C_TAG,"%s:%d (%s):%s", __FILE__, __LINE__, __FUNCTION__, str);      \
-        return (ret);                                                                   \
-        }
+static const char *I2C_TAG = "i2c";
+#define I2C_CHECK(a, str, ret)                                                 \
+  if (!(a)) {                                                                  \
+    ESP_LOGE(I2C_TAG, "%s:%d (%s):%s", __FILE__, __LINE__, __FUNCTION__, str); \
+    return (ret);                                                              \
+  }
 
-#define I2C_MASTER_NUM I2C_NUM_0                    /*!< I2C port number for master dev */
-#define I2C_MASTER_TX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
-#define I2C_MASTER_RX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
-#define I2C_MASTER_FREQ_HZ    100000     /*!< I2C master clock frequency */
+#define I2C_MASTER_NUM I2C_NUM_0    /*!< I2C port number for master dev */
+#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master do not need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master do not need buffer */
+#define I2C_MASTER_FREQ_HZ 100000   /*!< I2C master clock frequency */
 
-#define MA120_ADDR  CONFIG_DAC_I2C_ADDR  /*!< slave address for MA120 amplifier */
+#define MA120_ADDR                                           \
+  CONFIG_DAC_I2C_ADDR /*!< slave address for MA120 amplifier \
+                       */
 
-#define WRITE_BIT  I2C_MASTER_WRITE /*!< I2C master write */
-#define READ_BIT   I2C_MASTER_READ  /*!< I2C master read */
-#define ACK_CHECK_EN   0x1     /*!< I2C master will check ack from slave*/
-#define ACK_CHECK_DIS  0x0     /*!< I2C master will not check ack from slave */
-#define ACK_VAL    0x0         /*!< I2C ack value */
-#define NACK_VAL   0x1         /*!< I2C nack value */
-
-
+#define WRITE_BIT I2C_MASTER_WRITE /*!< I2C master write */
+#define READ_BIT I2C_MASTER_READ   /*!< I2C master read */
+#define ACK_CHECK_EN 0x1           /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS 0x0 /*!< I2C master will not check ack from slave */
+#define ACK_VAL 0x0       /*!< I2C ack value */
+#define NACK_VAL 0x1      /*!< I2C nack value */
 
 audio_hal_func_t AUDIO_CODEC_MA120_DEFAULT_HANDLE = {
     .audio_codec_initialize = ma120_init,
@@ -62,128 +62,119 @@ audio_hal_func_t AUDIO_CODEC_MA120_DEFAULT_HANDLE = {
     .handle = NULL,
 };
 
-esp_err_t ma120_deinit(void)
-{
-    // TODO
-    return ESP_OK;
+esp_err_t ma120_deinit(void) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t ma120_ctrl(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state)
-{
-    // TODO
-    return ESP_OK;
+esp_err_t ma120_ctrl(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t ma120_set_volume(int vol)
-{
-	esp_err_t ret = ESP_OK;
-	uint8_t cmd[2];
-	cmd[0] = 128-vol;
-	cmd[1] = cmd[0];
+esp_err_t ma120_set_volume(int vol) {
+  esp_err_t ret = ESP_OK;
+  uint8_t cmd[2];
+  cmd[0] = 128 - vol;
+  cmd[1] = cmd[0];
   ma_write(MA120_ADDR, 2, 0x0003, cmd, 2);
-	return ret;
+  return ret;
 }
 
-esp_err_t ma120_get_volume(int *vol)
-{
-	esp_err_t ret = ESP_OK;
-    uint8_t rxbuf;
-    rxbuf = ma_read_byte(MA120_ADDR, 2, 3);
-    *vol = 128 - rxbuf; 
-	return ret;
+esp_err_t ma120_get_volume(int *vol) {
+  esp_err_t ret = ESP_OK;
+  uint8_t rxbuf;
+  rxbuf = ma_read_byte(MA120_ADDR, 2, 3);
+  *vol = 128 - rxbuf;
+  return ret;
 }
 
-esp_err_t ma120_set_mute(bool enable)
-{
-	esp_err_t ret = ESP_OK;
+esp_err_t ma120_set_mute(bool enable) {
+  esp_err_t ret = ESP_OK;
   uint8_t nmute;
-  nmute = (enable) ? 0 : 1; 
-	gpio_set_level(MA_NMUTE_IO, nmute);
-	return ret;
+  nmute = (enable) ? 0 : 1;
+  gpio_set_level(MA_NMUTE_IO, nmute);
+  return ret;
 }
 
-esp_err_t ma120_get_mute(bool *enabled)
-{
-	esp_err_t ret = ESP_OK;
-   
-	*enabled = false;  // TODO read from register 
-	return ret;
+esp_err_t ma120_get_mute(bool *enabled) {
+  esp_err_t ret = ESP_OK;
+
+  *enabled = false;  // TODO read from register
+  return ret;
 }
 
-esp_err_t ma120_init(audio_hal_codec_config_t *codec_cfg)
-{
-   esp_err_t ret = ESP_OK;
-   gpio_config_t io_conf;
+esp_err_t ma120_init(audio_hal_codec_config_t *codec_cfg) {
+  esp_err_t ret = ESP_OK;
+  gpio_config_t io_conf;
 
-   io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-   io_conf.mode = GPIO_MODE_OUTPUT;
-   io_conf.pin_bit_mask = (1ULL<<MA_ENABLE_IO | 1ULL<<MA_NMUTE_IO );
-   io_conf.pull_down_en = 0;
-   io_conf.pull_up_en = 0;
+  io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
+  io_conf.mode = GPIO_MODE_OUTPUT;
+  io_conf.pin_bit_mask = (1ULL << MA_ENABLE_IO | 1ULL << MA_NMUTE_IO);
+  io_conf.pull_down_en = 0;
+  io_conf.pull_up_en = 0;
 
-   printf("setup output %d %d \n", MA_ENABLE_IO, MA_NMUTE_IO);
-   gpio_config(&io_conf);
+  printf("setup output %d %d \n", MA_ENABLE_IO, MA_NMUTE_IO);
+  gpio_config(&io_conf);
 
+  io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pin_bit_mask = (1ULL << MA_NCLIP_IO | 1ULL << MA_NERR_IO);
+  io_conf.pull_down_en = 0;
+  io_conf.pull_up_en = 0;
+  printf("setup input %d %d \n", MA_NCLIP_IO, MA_NERR_IO);
+  // gpio_config(&io_conf);
 
-   io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-   io_conf.mode = GPIO_MODE_INPUT;
-   io_conf.pin_bit_mask = (1ULL<<MA_NCLIP_IO | 1ULL<<MA_NERR_IO );
-   io_conf.pull_down_en = 0;
-   io_conf.pull_up_en = 0;
-   printf("setup input %d %d \n", MA_NCLIP_IO, MA_NERR_IO);
-   //gpio_config(&io_conf);
+  gpio_set_level(MA_NMUTE_IO, 0);
+  gpio_set_level(MA_ENABLE_IO, 0);
+  // required?
+  // gpio_set_drive_capability(I2C_MASTER_SCL_IO,2);
+  // gpio_set_drive_capability(I2C_MASTER_SDA_IO,2);
 
+  i2c_master_init();
 
-   gpio_set_level(MA_NMUTE_IO, 0);
-   gpio_set_level(MA_ENABLE_IO, 0);
-   // required?
-   // gpio_set_drive_capability(I2C_MASTER_SCL_IO,2);
-   // gpio_set_drive_capability(I2C_MASTER_SDA_IO,2);
+  gpio_set_level(MA_ENABLE_IO, 1);
 
-   i2c_master_init();
+  uint8_t res = ma_write_byte(MA120_ADDR, 2, 1544, 0);
+  res = ma_read_byte(MA120_ADDR, 2, 1544);
+  printf("Hardware version: 0x%02x\n", res);
+  printf("Scan I2C bus: ");
+  for (uint8_t addr = 0x20; addr <= 0x23; addr++) {
+    res = ma_read_byte(addr, 2, 0);
 
-   gpio_set_level(MA_ENABLE_IO, 1);
+    printf(" 0x%02x => GEN2 ,", addr);
+    // printf("Scan i2c address 0x%02x read address 0 : 0x%02x \n", addr ,res);
+  }
+  printf("\n");
+  uint8_t rxbuf[32];
+  uint8_t otp[1024];
+  for (uint8_t i = 0; i < 16; i++) {
+    ma_read(MA120_ADDR, 2, 0x8000 + i * 32, rxbuf, 32);
+    // printf("%04x : ",0x8000+i*32 );
+    for (uint8_t j = 0; j < 32; j++) {
+      otp[i * 32 + j] = rxbuf[j];
+    }
+  }
+  for (uint16_t i = 0; i < 16 * 32; i++) {
+    if (i % 32 == 0) {
+      printf("\n0x%04x : ", 0x8000 + i);
+    }
+    printf("%02x ", otp[i]);
+  }
 
-   uint8_t res = ma_write_byte(MA120_ADDR,2,1544,0);
-   res = ma_read_byte(MA120_ADDR,2,1544);
-   printf("Hardware version: 0x%02x\n",res);
-   printf("Scan I2C bus: ");
-   for (uint8_t addr = 0x20; addr <= 0x23 ; addr++ )
-   {  res = ma_read_byte(addr,2,0);
+  res = ma_write_byte(MA120_ADDR, 2, 0x060c, 0);
+  res = ma_read(MA120_ADDR, 2, 0x060c, rxbuf, 2);
+  printf("\nHardware version: 0x%02x\n", rxbuf[0]);
 
-      printf(" 0x%02x => GEN2 ,",addr);
-      //printf("Scan i2c address 0x%02x read address 0 : 0x%02x \n", addr ,res);
-   }
-   printf("\n");
-   uint8_t rxbuf[32];
-   uint8_t otp[1024];
-   for (uint8_t i=0;i<16; i++)
-   { ma_read(MA120_ADDR,2,0x8000+i*32,rxbuf,32);
-     //printf("%04x : ",0x8000+i*32 );
-     for (uint8_t j=0; j<32 ; j++ )
-     { otp[i*32+j] = rxbuf[j];
-     }
-   }
-   for (uint16_t i=0;i<16*32; i++)
-   { if (i%32==0) {
-     printf("\n0x%04x : ",0x8000+i);
-     }
-     printf("%02x ",otp[i]);
-   }
+  res = ma_read(MA120_ADDR, 2, 0x0000, rxbuf, 2);
+  printf("\nAddress 0 : 0x%02x\n", rxbuf[0]);
+  ma_write_byte(MA120_ADDR, 2, 0x0003, 0x50);
+  ma_write_byte(MA120_ADDR, 2, 0x0004, 0x50);
+  ma_write_byte(MA120_ADDR, 2, 0x0005, 0x02);
+  // ma_write_byte(MA120_ADDR,2,0x0246,0x00)  ;   //
+  printf("\n");
 
-   res = ma_write_byte(MA120_ADDR,2,0x060c,0);
-   res = ma_read(MA120_ADDR,2,0x060c,rxbuf,2);
-   printf("\nHardware version: 0x%02x\n",rxbuf[0]);
-
-   res = ma_read(MA120_ADDR,2,0x0000, rxbuf,2);
-   printf("\nAddress 0 : 0x%02x\n",rxbuf[0]);
-   ma_write_byte(MA120_ADDR,2,0x0003,0x50);
-   ma_write_byte(MA120_ADDR,2,0x0004,0x50);
-   ma_write_byte(MA120_ADDR,2,0x0005,0x02);
-   //ma_write_byte(MA120_ADDR,2,0x0246,0x00)  ;   //
-   printf("\n");
-
-   return ret;
+  return ret;
 }
 
 #define CRED "\x1b[31m"
@@ -193,162 +184,170 @@ esp_err_t ma120_init(audio_hal_codec_config_t *codec_cfg)
 #define CMAG "\x1b[35m"
 #define CYAN "\x1b[36m"
 #define CWHI "\x1b[0m"
-const char * cherr_str[]   = { "Clip_stuck", "DC", "VCF" , "OCP_SEV", "OCP" };
-const char * syserr1_str[] = { " X "," X ","DSP3 "," DSP2"," DSP1 ","DSP0 ","ERR","PVT_low" };
-const char * syserr0_str[] = { "OTW","OTE","PV_uv","PV_low","OV_ov"," CLK ","AUD"," TW    " };
-//static uint8_t terr = 0;
-void ma120_read_error(uint8_t i2c_addr)
-{ //0x0118 error now ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x0119 error now ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x011a error now system [ AE CE ... ]
-  //0x011b error now system [DSP3 DSP2 DSP1 DSP0 OC OE]
-  //0x011c error acc ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x011d error acc ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x011e error acc system [7..0]
-  //0x011f error acc system [13..8]
+const char *cherr_str[] = {"Clip_stuck", "DC", "VCF", "OCP_SEV", "OCP"};
+const char *syserr1_str[] = {" X ",    " X ",   "DSP3 ", " DSP2",
+                             " DSP1 ", "DSP0 ", "ERR",   "PVT_low"};
+const char *syserr0_str[] = {"OTW",   "OTE",   "PV_uv", "PV_low",
+                             "OV_ov", " CLK ", "AUD",   " TW    "};
+// static uint8_t terr = 0;
+void ma120_read_error(uint8_t i2c_addr) {  // 0x0118 error now ch0 [clip_stuck
+                                           // dc  vcf_err  ocp_severe  ocp]
+  // 0x0119 error now ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
+  // 0x011a error now system [ AE CE ... ]
+  // 0x011b error now system [DSP3 DSP2 DSP1 DSP0 OC OE]
+  // 0x011c error acc ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
+  // 0x011d error acc ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
+  // 0x011e error acc system [7..0]
+  // 0x011f error acc system [13..8]
   uint8_t errbuf[10] = {0};
 
-  ma_read(i2c_addr,2,0x0118,errbuf,8);
+  ma_read(i2c_addr, 2, 0x0118, errbuf, 8);
 
   // Error flag now : RED
   // Error flag acc : WHITE
-  // No falg set    : GREEN
-  for (int i = 0; i<=7;i++)
-  { //Error now
-    printf(" %s%s ",((errbuf[3] & (1<<i))==(1<<i)) ? CRED :
-                    ((errbuf[7] & (1<<i))==(1<<i)) ? CWHI : CGRE ,syserr1_str[i]);
+  // No flag set    : GREEN
+  for (int i = 0; i <= 7; i++) {  // Error now
+    printf(" %s%s ",
+           ((errbuf[3] & (1 << i)) == (1 << i))   ? CRED
+           : ((errbuf[7] & (1 << i)) == (1 << i)) ? CWHI
+                                                  : CGRE,
+           syserr1_str[i]);
   }
-  printf(" [0x%02x 0x%02x]\n",errbuf[3],errbuf[7]);
+  printf(" [0x%02x 0x%02x]\n", errbuf[3], errbuf[7]);
 
-  for (int i = 0; i<=7;i++)
-  {
-    printf(" %s%s ",((errbuf[2] & (1<<i))==(1<<i)) ? CRED :
-                    ((errbuf[6] & (1<<i))==(1<<i)) ? CWHI : CGRE ,syserr0_str[i]);
+  for (int i = 0; i <= 7; i++) {
+    printf(" %s%s ",
+           ((errbuf[2] & (1 << i)) == (1 << i))   ? CRED
+           : ((errbuf[6] & (1 << i)) == (1 << i)) ? CWHI
+                                                  : CGRE,
+           syserr0_str[i]);
   }
-  printf(" [0x%02x 0x%02x]\n",errbuf[2],errbuf[6]);
+  printf(" [0x%02x 0x%02x]\n", errbuf[2], errbuf[6]);
 
-  //printf("0x011b : 0x%02x %s", rxbuf[2], l1 );
-  //printf("\nError vectors :");
-  //for (int i = 0; i<8; i++)
+  // printf("0x011b : 0x%02x %s", rxbuf[2], l1 );
+  // printf("\nError vectors :");
+  // for (int i = 0; i<8; i++)
   //{ printf("%02x ", errbuf[i]);
   // }
-  //printf("\n");
+  // printf("\n");
 }
 
 static i2c_config_t i2c_cfg = {
-	   .mode = I2C_MODE_MASTER,
-	   .sda_pullup_en = GPIO_PULLUP_ENABLE,
-	   .scl_pullup_en = GPIO_PULLUP_ENABLE,
-	   .master.clk_speed = I2C_MASTER_FREQ_HZ,
-   };
- 
-void i2c_master_init()
-{  int i2c_master_port = I2C_MASTER_NUM;
+    .mode = I2C_MODE_MASTER,
+    .sda_pullup_en = GPIO_PULLUP_ENABLE,
+    .scl_pullup_en = GPIO_PULLUP_ENABLE,
+    .master.clk_speed = I2C_MASTER_FREQ_HZ,
+};
 
-  
-   get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+void i2c_master_init() {
+  int i2c_master_port = I2C_MASTER_NUM;
 
-   esp_err_t res = i2c_param_config(i2c_master_port, &i2c_cfg);
-   printf("Driver param setup : %d\n",res);
-   res = i2c_driver_install(i2c_master_port, i2c_cfg.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
-   printf("Driver installed   : %d\n",res);
+  get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+
+  esp_err_t res = i2c_param_config(i2c_master_port, &i2c_cfg);
+  printf("Driver param setup : %d\n", res);
+  res = i2c_driver_install(i2c_master_port, i2c_cfg.mode,
+                           I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE,
+                           0);
+  printf("Driver installed   : %d\n", res);
 }
 
-esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *wbuf, uint8_t n)
-{
+esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                   uint8_t *wbuf, uint8_t n) {
   bool ack = ACK_VAL;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, i2c_addr<<1 | WRITE_BIT, ACK_CHECK_EN);
+  i2c_master_write_byte(cmd, i2c_addr << 1 | WRITE_BIT, ACK_CHECK_EN);
   if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
   }
 
-  for (int i=0 ; i<n ; i++)
-  { if (i==n-1) ack = NACK_VAL;
+  for (int i = 0; i < n; i++) {
+    if (i == n - 1) ack = NACK_VAL;
     i2c_master_write_byte(cmd, wbuf[i], ack);
   }
   i2c_master_stop(cmd);
   int ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
-  if (ret == ESP_FAIL) { return ret; }
+  if (ret == ESP_FAIL) {
+    return ret;
+  }
   return ESP_OK;
 }
 
-esp_err_t ma_write_byte(uint8_t i2c_addr,uint8_t prot, uint16_t address, uint8_t value)
-{ printf("%04x %02x\n",address,value);
-  esp_err_t ret=0;
+esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                        uint8_t value) {
+  printf("%04x %02x\n", address, value);
+  esp_err_t ret = 0;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | WRITE_BIT , ACK_CHECK_EN);
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
   if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
   }
   i2c_master_write_byte(cmd, value, ACK_VAL);
   i2c_master_stop(cmd);
   ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
-     printf("ESP_I2C_WRITE ERROR : %d\n",ret);
-	 return ret;
+    printf("ESP_I2C_WRITE ERROR : %d\n", ret);
+    return ret;
   }
   return ESP_OK;
 }
 
-esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *rbuf, uint8_t n)
-{ esp_err_t ret;
+esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                  uint8_t *rbuf, uint8_t n) {
+  esp_err_t ret;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  if (cmd == NULL ) { printf("ERROR handle null\n"); }
-  i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | WRITE_BIT, ACK_CHECK_EN);
-  if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+  if (cmd == NULL) {
+    printf("ERROR handle null\n");
   }
   i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | READ_BIT, ACK_CHECK_EN);
-  //if (n == 1 )
-  i2c_master_read(cmd, rbuf, n-1 ,ACK_VAL);
- // for (uint8_t i = 0;i<n;i++)
- // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
-  i2c_master_read_byte(cmd, rbuf + n-1 , NACK_VAL);
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
+  if (prot == 2) {
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
+  }
+  i2c_master_start(cmd);
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
+  // if (n == 1 )
+  i2c_master_read(cmd, rbuf, n - 1, ACK_VAL);
+  // for (uint8_t i = 0;i<n;i++)
+  // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
+  i2c_master_read_byte(cmd, rbuf + n - 1, NACK_VAL);
   i2c_master_stop(cmd);
   ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
-      printf("i2c Error read - readback\n");
-	  return ESP_FAIL;
+    printf("i2c Error read - readback\n");
+    return ESP_FAIL;
   }
   return ret;
 }
 
-uint8_t ma_read_byte(uint8_t i2c_addr,uint8_t prot, uint16_t address)
-{
+uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address) {
   uint8_t value = 0;
   esp_err_t ret;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  i2c_master_start(cmd);								// Send i2c start on bus
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | WRITE_BIT, ACK_CHECK_EN );
+  i2c_master_start(cmd);  // Send i2c start on bus
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
   if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
   }
-  i2c_master_start(cmd);							    // Repeated start
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | READ_BIT, ACK_CHECK_EN);
+  i2c_master_start(cmd);  // Repeated start
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
 
   i2c_master_read_byte(cmd, &value, NACK_VAL);
 
@@ -356,8 +355,8 @@ uint8_t ma_read_byte(uint8_t i2c_addr,uint8_t prot, uint16_t address)
   ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
-      printf("i2c Error read - readback\n");
-	  return ESP_FAIL;
+    printf("i2c Error read - readback\n");
+    return ESP_FAIL;
   }
   return value;
 }

--- a/components/custom_board/ma120x0/MerusAudio.c
+++ b/components/custom_board/ma120x0/MerusAudio.c
@@ -9,45 +9,45 @@
 //
 //
 
-#include <stdio.h>
-#include <stdint.h>
-#include "esp_log.h"
-#include "driver/i2c.h"
-
 #include "MerusAudio.h"
 
+#include <stdint.h>
+#include <stdio.h>
+
+#include "driver/i2c.h"
+#include "esp_log.h"
 #include "ma120x0.h"
 //#include "ma120_rev1_all.h"
 
 static const char *TAG = "MA120X0";
 
-#define MA_NENABLE_IO  CONFIG_MA120X0_NENABLE_PIN
-#define MA_ENABLE_IO   CONFIG_MA120X0_ENABLE_PIN
-#define MA_NMUTE_IO    CONFIG_MA120X0_NMUTE_PIN
-#define MA_NERR_IO     CONFIG_MA120X0_NERR_PIN
-#define MA_NCLIP_IO    CONFIG_MA120X0_NCLIP_PIN
+#define MA_NENABLE_IO CONFIG_MA120X0_NENABLE_PIN
+#define MA_ENABLE_IO CONFIG_MA120X0_ENABLE_PIN
+#define MA_NMUTE_IO CONFIG_MA120X0_NMUTE_PIN
+#define MA_NERR_IO CONFIG_MA120X0_NERR_PIN
+#define MA_NCLIP_IO CONFIG_MA120X0_NCLIP_PIN
 
+static const char *I2C_TAG = "i2c";
+#define I2C_CHECK(a, str, ret)                                                 \
+  if (!(a)) {                                                                  \
+    ESP_LOGE(I2C_TAG, "%s:%d (%s):%s", __FILE__, __LINE__, __FUNCTION__, str); \
+    return (ret);                                                              \
+  }
 
-static const char* I2C_TAG = "i2c";
-#define I2C_CHECK(a, str, ret)  if(!(a)) {                                             \
-        ESP_LOGE(I2C_TAG,"%s:%d (%s):%s", __FILE__, __LINE__, __FUNCTION__, str);      \
-        return (ret);                                                                   \
-        }
+#define I2C_MASTER_NUM I2C_NUM_0    /*!< I2C port number for master dev */
+#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master do not need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master do not need buffer */
+#define I2C_MASTER_FREQ_HZ 100000   /*!< I2C master clock frequency */
 
-#define I2C_MASTER_NUM I2C_NUM_0                    /*!< I2C port number for master dev */
-#define I2C_MASTER_TX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
-#define I2C_MASTER_RX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
-#define I2C_MASTER_FREQ_HZ    100000     /*!< I2C master clock frequency */
+#define MA120X0_ADDR \
+  CONFIG_DAC_I2C_ADDR /*!< slave address for MA120X0 amplifier */
 
-#define MA120X0_ADDR  CONFIG_DAC_I2C_ADDR  /*!< slave address for MA120X0 amplifier */
-
-#define WRITE_BIT  I2C_MASTER_WRITE /*!< I2C master write */
-#define READ_BIT   I2C_MASTER_READ  /*!< I2C master read */
-#define ACK_CHECK_EN   0x1     /*!< I2C master will check ack from slave*/
-#define ACK_CHECK_DIS  0x0     /*!< I2C master will not check ack from slave */
-#define ACK_VAL    0x0         /*!< I2C ack value */
-#define NACK_VAL   0x1         /*!< I2C nack value */
-
+#define WRITE_BIT I2C_MASTER_WRITE /*!< I2C master write */
+#define READ_BIT I2C_MASTER_READ   /*!< I2C master read */
+#define ACK_CHECK_EN 0x1           /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS 0x0 /*!< I2C master will not check ack from slave */
+#define ACK_VAL 0x0       /*!< I2C ack value */
+#define NACK_VAL 0x1      /*!< I2C nack value */
 
 static i2c_config_t i2c_cfg;
 
@@ -63,132 +63,123 @@ audio_hal_func_t AUDIO_CODEC_MA120X0_DEFAULT_HANDLE = {
     .handle = NULL,
 };
 
-esp_err_t ma120x0_deinit(void)
-{
-    // TODO
-    return ESP_OK;
+esp_err_t ma120x0_deinit(void) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t ma120x0_ctrl(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state)
-{
-    // TODO
-    return ESP_OK;
+esp_err_t ma120x0_ctrl(audio_hal_codec_mode_t mode,
+                       audio_hal_ctrl_t ctrl_state) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t ma120x0_config_iface(audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface)
-{
-    //TODO
-    return ESP_OK;
+esp_err_t ma120x0_config_iface(audio_hal_codec_mode_t mode,
+                               audio_hal_codec_i2s_iface_t *iface) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t ma120x0_set_volume(int vol)
-{
-	esp_err_t ret = ESP_OK;
-	uint8_t cmd;
-	cmd = 128-vol;
-	ma_write_byte(0x20, 1, 64, cmd);
-	return ret;
+esp_err_t ma120x0_set_volume(int vol) {
+  esp_err_t ret = ESP_OK;
+  uint8_t cmd;
+  cmd = 128 - vol;
+  ma_write_byte(0x20, 1, 64, cmd);
+  return ret;
 }
 
-esp_err_t ma120x0_get_volume(int *vol)
-{
-	esp_err_t ret = ESP_OK;
-    uint8_t rxbuf;
-    rxbuf = ma_read_byte(0x20, 1, 64, rxbuf);
-    *vol = 128 - rxbuf; 
-	return ret;
+esp_err_t ma120x0_get_volume(int *vol) {
+  esp_err_t ret = ESP_OK;
+  uint8_t rxbuf;
+  rxbuf = ma_read_byte(0x20, 1, 64, rxbuf);
+  *vol = 128 - rxbuf;
+  return ret;
 }
 
-esp_err_t ma120x0_set_mute(bool enable)
-{
-	esp_err_t ret = ESP_OK;
-  uint8_t nmute = (enable) ? 0 : 1 
-	gpio_set_level(MA_NMUTE_IO, nmute);
-	return ret;
+esp_err_t ma120x0_set_mute(bool enable) {
+  esp_err_t ret = ESP_OK;
+  uint8_t nmute = (enable) ? 0 : 1 gpio_set_level(MA_NMUTE_IO, nmute);
+  return ret;
 }
 
-esp_err_t ma120x0_get_mute(bool *enabled)
-{
-	esp_err_t ret = ESP_OK;
-   
-	*enabled = false;  // TODO read from register 
-	return ret;
+esp_err_t ma120x0_get_mute(bool *enabled) {
+  esp_err_t ret = ESP_OK;
+
+  *enabled = false;  // TODO read from register
+  return ret;
 }
 
-esp_err_t ma120x0_init(audio_hal_codec_config_t *codec_cfg)
-{
-   esp_err_t ret = ESP_OK;
-   gpio_config_t io_conf;
+esp_err_t ma120x0_init(audio_hal_codec_config_t *codec_cfg) {
+  esp_err_t ret = ESP_OK;
+  gpio_config_t io_conf;
 
-   io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-   io_conf.mode = GPIO_MODE_OUTPUT;
-   io_conf.pin_bit_mask = (1ULL<<MA_ENABLE_IO | 1ULL<<MA_NMUTE_IO );
-   io_conf.pull_down_en = 0;
-   io_conf.pull_up_en = 0;
+  io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
+  io_conf.mode = GPIO_MODE_OUTPUT;
+  io_conf.pin_bit_mask = (1ULL << MA_ENABLE_IO | 1ULL << MA_NMUTE_IO);
+  io_conf.pull_down_en = 0;
+  io_conf.pull_up_en = 0;
 
-   printf("setup output %d %d \n", MA_ENABLE_IO, MA_NMUTE_IO);
-   gpio_config(&io_conf);
+  printf("setup output %d %d \n", MA_ENABLE_IO, MA_NMUTE_IO);
+  gpio_config(&io_conf);
 
+  io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pin_bit_mask = (1ULL << MA_NCLIP_IO | 1ULL << MA_NERR_IO);
+  io_conf.pull_down_en = 0;
+  io_conf.pull_up_en = 0;
+  printf("setup input %d %d \n", MA_NCLIP_IO, MA_NERR_IO);
+  gpio_config(&io_conf);
 
-   io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-   io_conf.mode = GPIO_MODE_INPUT;
-   io_conf.pin_bit_mask = (1ULL<<MA_NCLIP_IO | 1ULL<<MA_NERR_IO );
-   io_conf.pull_down_en = 0;
-   io_conf.pull_up_en = 0;
-   printf("setup input %d %d \n", MA_NCLIP_IO, MA_NERR_IO);
-   gpio_config(&io_conf);
+  gpio_set_level(MA_NMUTE_IO, 0);
+  gpio_set_level(MA_ENABLE_IO, 0);
+  // required?
+  // gpio_set_drive_capability(I2C_MASTER_SCL_IO,2);
+  // gpio_set_drive_capability(I2C_MASTER_SDA_IO,2);
 
+  i2c_master_init();
 
-   gpio_set_level(MA_NMUTE_IO, 0);
-   gpio_set_level(MA_ENABLE_IO, 0);
-   // required?
-   // gpio_set_drive_capability(I2C_MASTER_SCL_IO,2);
-   // gpio_set_drive_capability(I2C_MASTER_SDA_IO,2);
+  gpio_set_level(MA_ENABLE_IO, 1);
 
-   i2c_master_init();
+  uint8_t res = ma_write_byte(0x20, 2, 1544, 0);
+  res = ma_read_byte(0x20, 2, 1544);
+  printf("Hardware version: 0x%02x\n", res);
+  printf("Scan I2C bus: ");
+  for (uint8_t addr = 0x20; addr <= 0x23; addr++) {
+    res = ma_read_byte(addr, 2, 0);
 
-   gpio_set_level(MA_ENABLE_IO, 1);
+    printf(" 0x%02x => GEN2 ,", addr);
+    // printf("Scan i2c address 0x%02x read address 0 : 0x%02x \n", addr ,res);
+  }
+  printf("\n");
+  uint8_t rxbuf[32];
+  uint8_t otp[1024];
+  for (uint8_t i = 0; i < 16; i++) {
+    ma_read(0x20, 2, 0x8000 + i * 32, rxbuf, 32);
+    // printf("%04x : ",0x8000+i*32 );
+    for (uint8_t j = 0; j < 32; j++) {
+      otp[i * 32 + j] = rxbuf[j];
+    }
+  }
+  for (uint16_t i = 0; i < 16 * 32; i++) {
+    if (i % 32 == 0) {
+      printf("\n0x%04x : ", 0x8000 + i);
+    }
+    printf("%02x ", otp[i]);
+  }
 
-   uint8_t res = ma_write_byte(0x20,2,1544,0);
-   res = ma_read_byte(0x20,2,1544);
-   printf("Hardware version: 0x%02x\n",res);
-   printf("Scan I2C bus: ");
-   for (uint8_t addr = 0x20; addr <= 0x23 ; addr++ )
-   {  res = ma_read_byte(addr,2,0);
+  res = ma_write_byte(0x20, 2, 0x060c, 0);
+  res = ma_read(0x20, 2, 0x060c, rxbuf, 2);
+  printf("\nHardware version: 0x%02x\n", rxbuf[0]);
 
-      printf(" 0x%02x => GEN2 ,",addr);
-      //printf("Scan i2c address 0x%02x read address 0 : 0x%02x \n", addr ,res);
-   }
-   printf("\n");
-   uint8_t rxbuf[32];
-   uint8_t otp[1024];
-   for (uint8_t i=0;i<16; i++)
-   { ma_read(0x20,2,0x8000+i*32,rxbuf,32);
-     //printf("%04x : ",0x8000+i*32 );
-     for (uint8_t j=0; j<32 ; j++ )
-     { otp[i*32+j] = rxbuf[j];
-     }
-   }
-   for (uint16_t i=0;i<16*32; i++)
-   { if (i%32==0) {
-     printf("\n0x%04x : ",0x8000+i);
-     }
-     printf("%02x ",otp[i]);
-   }
+  res = ma_read(0x20, 2, 0x0000, rxbuf, 2);
+  printf("\nAddress 0 : 0x%02x\n", rxbuf[0]);
+  ma_write_byte(0x20, 2, 0x0003, 0x50);
+  ma_write_byte(0x20, 2, 0x0004, 0x50);
+  ma_write_byte(0x20, 2, 0x0005, 0x02);
+  // ma_write_byte(0x20,2,0x0246,0x00)  ;   //
+  printf("\n");
 
-   res = ma_write_byte(0x20,2,0x060c,0);
-   res = ma_read(0x20,2,0x060c,rxbuf,2);
-   printf("\nHardware version: 0x%02x\n",rxbuf[0]);
-
-   res = ma_read(0x20,2,0x0000, rxbuf,2);
-   printf("\nAddress 0 : 0x%02x\n",rxbuf[0]);
-   ma_write_byte(0x20,2,0x0003,0x50);
-   ma_write_byte(0x20,2,0x0004,0x50);
-   ma_write_byte(0x20,2,0x0005,0x02);
-   //ma_write_byte(0x20,2,0x0246,0x00)  ;   //
-   printf("\n");
-
-   return ret;
+  return ret;
 }
 
 #define CRED "\x1b[31m"
@@ -198,159 +189,168 @@ esp_err_t ma120x0_init(audio_hal_codec_config_t *codec_cfg)
 #define CMAG "\x1b[35m"
 #define CYAN "\x1b[36m"
 #define CWHI "\x1b[0m"
-const char * cherr_str[]   = { "Clip_stuck", "DC", "VCF" , "OCP_SEV", "OCP" };
-const char * syserr1_str[] = { " X "," X ","DSP3 "," DSP2"," DSP1 ","DSP0 ","ERR","PVT_low" };
-const char * syserr0_str[] = { "OTW","OTE","PV_uv","PV_low","OV_ov"," CLK ","AUD"," TW    " };
-//static uint8_t terr = 0;
-void ma120_read_error(uint8_t i2c_addr)
-{ //0x0118 error now ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x0119 error now ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x011a error now system [ AE CE ... ]
-  //0x011b error now system [DSP3 DSP2 DSP1 DSP0 OC OE]
-  //0x011c error acc ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x011d error acc ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  //0x011e error acc system [7..0]
-  //0x011f error acc system [13..8]
+const char *cherr_str[] = {"Clip_stuck", "DC", "VCF", "OCP_SEV", "OCP"};
+const char *syserr1_str[] = {" X ",    " X ",   "DSP3 ", " DSP2",
+                             " DSP1 ", "DSP0 ", "ERR",   "PVT_low"};
+const char *syserr0_str[] = {"OTW",   "OTE",   "PV_uv", "PV_low",
+                             "OV_ov", " CLK ", "AUD",   " TW    "};
+// static uint8_t terr = 0;
+void ma120_read_error(uint8_t i2c_addr) {  // 0x0118 error now ch0 [clip_stuck
+                                           // dc  vcf_err  ocp_severe  ocp]
+  // 0x0119 error now ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
+  // 0x011a error now system [ AE CE ... ]
+  // 0x011b error now system [DSP3 DSP2 DSP1 DSP0 OC OE]
+  // 0x011c error acc ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
+  // 0x011d error acc ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
+  // 0x011e error acc system [7..0]
+  // 0x011f error acc system [13..8]
   uint8_t errbuf[10] = {0};
 
-  uint8_t res = ma_read(i2c_addr,2,0x0118,errbuf,8);
+  uint8_t res = ma_read(i2c_addr, 2, 0x0118, errbuf, 8);
 
   // Error flag now : RED
   // Error flag acc : WHITE
-  // No falg set    : GREEN
-  for (int i = 0; i<=7;i++)
-  { //Error now
-    printf(" %s%s ",((errbuf[3] & (1<<i))==(1<<i)) ? CRED :
-                    ((errbuf[7] & (1<<i))==(1<<i)) ? CWHI : CGRE ,syserr1_str[i]);
+  // No flag set    : GREEN
+  for (int i = 0; i <= 7; i++) {  // Error now
+    printf(" %s%s ",
+           ((errbuf[3] & (1 << i)) == (1 << i))   ? CRED
+           : ((errbuf[7] & (1 << i)) == (1 << i)) ? CWHI
+                                                  : CGRE,
+           syserr1_str[i]);
   }
-  printf(" [0x%02x 0x%02x]\n",errbuf[3],errbuf[7]);
+  printf(" [0x%02x 0x%02x]\n", errbuf[3], errbuf[7]);
 
-  for (int i = 0; i<=7;i++)
-  {
-    printf(" %s%s ",((errbuf[2] & (1<<i))==(1<<i)) ? CRED :
-                    ((errbuf[6] & (1<<i))==(1<<i)) ? CWHI : CGRE ,syserr0_str[i]);
+  for (int i = 0; i <= 7; i++) {
+    printf(" %s%s ",
+           ((errbuf[2] & (1 << i)) == (1 << i))   ? CRED
+           : ((errbuf[6] & (1 << i)) == (1 << i)) ? CWHI
+                                                  : CGRE,
+           syserr0_str[i]);
   }
-  printf(" [0x%02x 0x%02x]\n",errbuf[2],errbuf[6]);
+  printf(" [0x%02x 0x%02x]\n", errbuf[2], errbuf[6]);
 
-  //printf("0x011b : 0x%02x %s", rxbuf[2], l1 );
-  //printf("\nError vectors :");
-  //for (int i = 0; i<8; i++)
+  // printf("0x011b : 0x%02x %s", rxbuf[2], l1 );
+  // printf("\nError vectors :");
+  // for (int i = 0; i<8; i++)
   //{ printf("%02x ", errbuf[i]);
   // }
-  //printf("\n");
+  // printf("\n");
 }
 
-void i2c_master_init()
-{  int i2c_master_port = I2C_MASTER_NUM;
-   i2c_cfg = {
-	   .mode = I2C_MODE_MASTER,
-	   .sda_pullup_en = GPIO_PULLUP_ENABLE,
-	   .scl_pullup_en = GPIO_PULLUP_ENABLE,
-	   .master.clk_speed = I2C_MASTER_FREQ_HZ,
-   };
-   get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+void i2c_master_init() {
+  int i2c_master_port = I2C_MASTER_NUM;
+  i2c_cfg = {
+      .mode = I2C_MODE_MASTER,
+      .sda_pullup_en = GPIO_PULLUP_ENABLE,
+      .scl_pullup_en = GPIO_PULLUP_ENABLE,
+      .master.clk_speed = I2C_MASTER_FREQ_HZ,
+  };
+  get_i2c_pins(I2C_NUM_0, &i2c_cfg);
 
-   esp_err_t res = i2c_param_config(i2c_master_port, &i2c_cfg);
-   printf("Driver param setup : %d\n",res);
-   res = i2c_driver_install(i2c_master_port, i2c_cfg.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
-   printf("Driver installed   : %d\n",res);
+  esp_err_t res = i2c_param_config(i2c_master_port, &i2c_cfg);
+  printf("Driver param setup : %d\n", res);
+  res = i2c_driver_install(i2c_master_port, i2c_cfg.mode,
+                           I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE,
+                           0);
+  printf("Driver installed   : %d\n", res);
 }
 
-esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *wbuf, uint8_t n)
-{
+esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                   uint8_t *wbuf, uint8_t n) {
   bool ack = ACK_VAL;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, i2c_addr<<1 | WRITE_BIT, ACK_CHECK_EN);
+  i2c_master_write_byte(cmd, i2c_addr << 1 | WRITE_BIT, ACK_CHECK_EN);
   if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
   }
 
-  for (int i=0 ; i<n ; i++)
-  { if (i==n-1) ack = NACK_VAL;
+  for (int i = 0; i < n; i++) {
+    if (i == n - 1) ack = NACK_VAL;
     i2c_master_write_byte(cmd, wbuf[i], ack);
   }
   i2c_master_stop(cmd);
   int ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
-  if (ret == ESP_FAIL) { return ret; }
+  if (ret == ESP_FAIL) {
+    return ret;
+  }
   return ESP_OK;
 }
 
-esp_err_t ma_write_byte(uint8_t i2c_addr,uint8_t prot, uint16_t address, uint8_t value)
-{ printf("%04x %02x\n",address,value);
-  esp_err_t ret=0;
+esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                        uint8_t value) {
+  printf("%04x %02x\n", address, value);
+  esp_err_t ret = 0;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | WRITE_BIT , ACK_CHECK_EN);
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
   if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
   }
   i2c_master_write_byte(cmd, value, ACK_VAL);
   i2c_master_stop(cmd);
   ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
-     printf("ESP_I2C_WRITE ERROR : %d\n",ret);
-	 return ret;
+    printf("ESP_I2C_WRITE ERROR : %d\n", ret);
+    return ret;
   }
   return ESP_OK;
 }
 
-esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *rbuf, uint8_t n)
-{ esp_err_t ret;
+esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                  uint8_t *rbuf, uint8_t n) {
+  esp_err_t ret;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  if (cmd == NULL ) { printf("ERROR handle null\n"); }
-  i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | WRITE_BIT, ACK_CHECK_EN);
-  if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+  if (cmd == NULL) {
+    printf("ERROR handle null\n");
   }
   i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | READ_BIT, ACK_CHECK_EN);
-  //if (n == 1 )
-  i2c_master_read(cmd, rbuf, n-1 ,ACK_VAL);
- // for (uint8_t i = 0;i<n;i++)
- // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
-  i2c_master_read_byte(cmd, rbuf + n-1 , NACK_VAL);
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
+  if (prot == 2) {
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
+  }
+  i2c_master_start(cmd);
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
+  // if (n == 1 )
+  i2c_master_read(cmd, rbuf, n - 1, ACK_VAL);
+  // for (uint8_t i = 0;i<n;i++)
+  // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
+  i2c_master_read_byte(cmd, rbuf + n - 1, NACK_VAL);
   i2c_master_stop(cmd);
   ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
-      printf("i2c Error read - readback\n");
-	  return ESP_FAIL;
+    printf("i2c Error read - readback\n");
+    return ESP_FAIL;
   }
   return ret;
 }
 
-uint8_t ma_read_byte(uint8_t i2c_addr,uint8_t prot, uint16_t address)
-{
+uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address) {
   uint8_t value = 0;
   esp_err_t ret;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  i2c_master_start(cmd);								// Send i2c start on bus
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | WRITE_BIT, ACK_CHECK_EN );
+  i2c_master_start(cmd);  // Send i2c start on bus
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
   if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address&0xff00)>>8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address&0x00ff), ACK_VAL);
-  } else
-  {
-    i2c_master_write_byte(cmd, (uint8_t) address, ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+  } else {
+    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
   }
-  i2c_master_start(cmd);							    // Repeated start
-  i2c_master_write_byte(cmd, (i2c_addr<<1) | READ_BIT, ACK_CHECK_EN);
+  i2c_master_start(cmd);  // Repeated start
+  i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
 
   i2c_master_read_byte(cmd, &value, NACK_VAL);
 
@@ -358,8 +358,8 @@ uint8_t ma_read_byte(uint8_t i2c_addr,uint8_t prot, uint16_t address)
   ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
-      printf("i2c Error read - readback\n");
-	  return ESP_FAIL;
+    printf("i2c Error read - readback\n");
+    return ESP_FAIL;
   }
   return value;
 }

--- a/components/custom_board/ma120x0/include/MerusAudio.h
+++ b/components/custom_board/ma120x0/include/MerusAudio.h
@@ -1,6 +1,6 @@
-#ifndef _MERUSAUDIO_H_ 
+#ifndef _MERUSAUDIO_H_
 #define _MERUSAUDIO_H_
-  
+
 void setup_ma120x0(void);
 void setup_ma120(void);
 void ma120_read_error(uint8_t i2c_addr);
@@ -8,13 +8,13 @@ void ma120_setup_audio(uint8_t i2c_addr);
 
 void i2c_master_init(void);
 
-esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t value); 
-esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *wbuf, uint8_t n);
- 
+esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                        uint8_t value);
+esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                   uint8_t *wbuf, uint8_t n);
+
 uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address);
-esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address, uint8_t *rbuf, uint8_t n);
+esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
+                  uint8_t *rbuf, uint8_t n);
 
-
-#endif /* _MERUSAUDIO_H_  */ 
-
-  
+#endif /* _MERUSAUDIO_H_  */

--- a/components/custom_board/ma120x0/include/ma120x0.h
+++ b/components/custom_board/ma120x0/include/ma120x0.h
@@ -1,1226 +1,1922 @@
 /*---------------------------------------------------------------------------------------*/
-/*   Merus Audio MA120x0 register map                                                    */
+/*   Merus Audio MA120x0 register map */
 /*                                                                                       */
-/*   Provides : Defines for registers and symbols in merus audio amplifiers              */
-/*              Macros for set and get content of symbols                                */
-/*              Read-modify-write on write to symbols less then 8 bits                   */
+/*   Provides : Defines for registers and symbols in merus audio amplifiers */
+/*              Macros for set and get content of symbols */
+/*              Read-modify-write on write to symbols less then 8 bits */
 /*                                                                                       */
-/*   Symbols is a collection of 1 to 8 bits within a single address                      */
+/*   Symbols is a collection of 1 to 8 bits within a single address */
 /*                                                                                       */
-/*   Provided as is - free to use and share                                              */
+/*   Provided as is - free to use and share */
 /*                                                                                       */
-/*   Timestamp                        :                         Thu Feb 23 23:06:51 2017 */
-/*   Created from database            :                     ma12070_register_spec_rev6_1 */
-/*   Errors and updates please contact:       Jorgen Kragh Jakobsen, jkj@merus-audio.com */
+/*   Timestamp                        :                         Thu Feb 23
+ * 23:06:51 2017 */
+/*   Created from database            : ma12070_register_spec_rev6_1 */
+/*   Errors and updates please contact:       Jorgen Kragh Jakobsen,
+ * jkj@merus-audio.com */
 /*---------------------------------------------------------------------------------------*/
 
 #include <stdint.h>
 
-
-#ifndef _MA120X0_H_ 
-#define _MA120X0_H_ 
-
+#ifndef _MA120X0_H_
+#define _MA120X0_H_
 
 //------------------------------------------------------------------------------manualPM---
-// Select Manual PowerMode control 
+// Select Manual PowerMode control
 #define MA_manualPM__a 0
 #define MA_manualPM__len 1
 #define MA_manualPM__mask 0x40
 #define MA_manualPM__shift 0x06
 #define MA_manualPM__reset 0x00
-#define set_obj_MA_manualPM(o,y) ({ uint8_t __ret = o.read(0); o.write(0,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_manualPM(y) ({ uint8_t __ret = ma_read_byte(0); ma_write_byte(0,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_manualPM(o) (o.read(0) & 0x40)>>6 
-#define get_MA_manualPM() ( ma_read_byte(0) & 0x40)>>6 
+#define set_obj_MA_manualPM(o, y)                   \
+  ({                                                \
+    uint8_t __ret = o.read(0);                      \
+    o.write(0, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_manualPM(y)                                \
+  ({                                                      \
+    uint8_t __ret = ma_read_byte(0);                      \
+    ma_write_byte(0, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_manualPM(o) (o.read(0) & 0x40) >> 6
+#define get_MA_manualPM() (ma_read_byte(0) & 0x40) >> 6
 //------------------------------------------------------------------------------PM_man---
-// Manual selected power mode 
+// Manual selected power mode
 #define MA_PM_man__a 0
 #define MA_PM_man__len 2
 #define MA_PM_man__mask 0x30
 #define MA_PM_man__shift 0x04
 #define MA_PM_man__reset 0x03
-#define set_obj_MA_PM_man(o,y) ({ uint8_t __ret = o.read(0); o.write(0,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_PM_man(y) ({ uint8_t __ret = ma_read_byte(0); ma_write_byte(0,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_PM_man(o) (o.read(0) & 0x30)>>4 
-#define get_MA_PM_man() ( ma_read_byte(0) & 0x30)>>4 
+#define set_obj_MA_PM_man(o, y)                     \
+  ({                                                \
+    uint8_t __ret = o.read(0);                      \
+    o.write(0, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_PM_man(y)                                  \
+  ({                                                      \
+    uint8_t __ret = ma_read_byte(0);                      \
+    ma_write_byte(0, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_PM_man(o) (o.read(0) & 0x30) >> 4
+#define get_MA_PM_man() (ma_read_byte(0) & 0x30) >> 4
 //------------------------------------------------------------------------------Mthr_1to2---
-// Mod. index threshold value for PM1=>PM2 change. 
+// Mod. index threshold value for PM1=>PM2 change.
 #define MA_Mthr_1to2__a 1
 #define MA_Mthr_1to2__len 8
 #define MA_Mthr_1to2__mask 0xff
 #define MA_Mthr_1to2__shift 0x00
 #define MA_Mthr_1to2__reset 0x3c
-#define set_obj_MA_Mthr_1to2(o,y) o.write(1,y);
-#define set_MA_Mthr_1to2(y) ma_write_byte(1,y);
-#define get_obj_MA_Mthr_1to2(o) (o.read(1) & 0xff)>>0 
-#define get_MA_Mthr_1to2() ( ma_read_byte(1) & 0xff)>>0 
+#define set_obj_MA_Mthr_1to2(o, y) o.write(1, y);
+#define set_MA_Mthr_1to2(y) ma_write_byte(1, y);
+#define get_obj_MA_Mthr_1to2(o) (o.read(1) & 0xff) >> 0
+#define get_MA_Mthr_1to2() (ma_read_byte(1) & 0xff) >> 0
 //------------------------------------------------------------------------------Mthr_2to1---
-// Mod. index threshold value for PM2=>PM1 change. 
+// Mod. index threshold value for PM2=>PM1 change.
 #define MA_Mthr_2to1__a 2
 #define MA_Mthr_2to1__len 8
 #define MA_Mthr_2to1__mask 0xff
 #define MA_Mthr_2to1__shift 0x00
 #define MA_Mthr_2to1__reset 0x32
-#define set_obj_MA_Mthr_2to1(o,y) o.write(2,y);
-#define set_MA_Mthr_2to1(y) ma_write_byte(2,y);
-#define get_obj_MA_Mthr_2to1(o) (o.read(2) & 0xff)>>0 
-#define get_MA_Mthr_2to1() ( ma_read_byte(2) & 0xff)>>0 
+#define set_obj_MA_Mthr_2to1(o, y) o.write(2, y);
+#define set_MA_Mthr_2to1(y) ma_write_byte(2, y);
+#define get_obj_MA_Mthr_2to1(o) (o.read(2) & 0xff) >> 0
+#define get_MA_Mthr_2to1() (ma_read_byte(2) & 0xff) >> 0
 //------------------------------------------------------------------------------Mthr_2to3---
-// Mod. index threshold value for PM2=>PM3 change. 
+// Mod. index threshold value for PM2=>PM3 change.
 #define MA_Mthr_2to3__a 3
 #define MA_Mthr_2to3__len 8
 #define MA_Mthr_2to3__mask 0xff
 #define MA_Mthr_2to3__shift 0x00
 #define MA_Mthr_2to3__reset 0x5a
-#define set_obj_MA_Mthr_2to3(o,y) o.write(3,y);
-#define set_MA_Mthr_2to3(y) ma_write_byte(3,y);
-#define get_obj_MA_Mthr_2to3(o) (o.read(3) & 0xff)>>0 
-#define get_MA_Mthr_2to3() ( ma_read_byte(3) & 0xff)>>0 
+#define set_obj_MA_Mthr_2to3(o, y) o.write(3, y);
+#define set_MA_Mthr_2to3(y) ma_write_byte(3, y);
+#define get_obj_MA_Mthr_2to3(o) (o.read(3) & 0xff) >> 0
+#define get_MA_Mthr_2to3() (ma_read_byte(3) & 0xff) >> 0
 //------------------------------------------------------------------------------Mthr_3to2---
-// Mod. index threshold value for PM3=>PM2 change. 
+// Mod. index threshold value for PM3=>PM2 change.
 #define MA_Mthr_3to2__a 4
 #define MA_Mthr_3to2__len 8
 #define MA_Mthr_3to2__mask 0xff
 #define MA_Mthr_3to2__shift 0x00
 #define MA_Mthr_3to2__reset 0x50
-#define set_obj_MA_Mthr_3to2(o,y) o.write(4,y);
-#define set_MA_Mthr_3to2(y) ma_write_byte(4,y);
-#define get_obj_MA_Mthr_3to2(o) (o.read(4) & 0xff)>>0 
-#define get_MA_Mthr_3to2() ( ma_read_byte(4) & 0xff)>>0 
+#define set_obj_MA_Mthr_3to2(o, y) o.write(4, y);
+#define set_MA_Mthr_3to2(y) ma_write_byte(4, y);
+#define get_obj_MA_Mthr_3to2(o) (o.read(4) & 0xff) >> 0
+#define get_MA_Mthr_3to2() (ma_read_byte(4) & 0xff) >> 0
 //------------------------------------------------------------------------------pwmClkDiv_nom---
-// PWM default clock divider value 
+// PWM default clock divider value
 #define MA_pwmClkDiv_nom__a 8
 #define MA_pwmClkDiv_nom__len 8
 #define MA_pwmClkDiv_nom__mask 0xff
 #define MA_pwmClkDiv_nom__shift 0x00
 #define MA_pwmClkDiv_nom__reset 0x26
-#define set_obj_MA_pwmClkDiv_nom(o,y) o.write(8,y);
-#define set_MA_pwmClkDiv_nom(y) ma_write_byte(8,y);
-#define get_obj_MA_pwmClkDiv_nom(o) (o.read(8) & 0xff)>>0 
-#define get_MA_pwmClkDiv_nom() ( ma_read_byte(8) & 0xff)>>0 
+#define set_obj_MA_pwmClkDiv_nom(o, y) o.write(8, y);
+#define set_MA_pwmClkDiv_nom(y) ma_write_byte(8, y);
+#define get_obj_MA_pwmClkDiv_nom(o) (o.read(8) & 0xff) >> 0
+#define get_MA_pwmClkDiv_nom() (ma_read_byte(8) & 0xff) >> 0
 //------------------------------------------------------------------------------ocp_latch_en---
-// High to use permanently latching level-2 OCP 
+// High to use permanently latching level-2 OCP
 #define MA_ocp_latch_en__a 10
 #define MA_ocp_latch_en__len 1
 #define MA_ocp_latch_en__mask 0x02
 #define MA_ocp_latch_en__shift 0x01
 #define MA_ocp_latch_en__reset 0x00
-#define set_obj_MA_ocp_latch_en(o,y) ({ uint8_t __ret = o.read(10); o.write(10,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_ocp_latch_en(y) ({ uint8_t __ret = ma_read_byte(10); ma_write_byte(10,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_ocp_latch_en(o) (o.read(10) & 0x02)>>1 
-#define get_MA_ocp_latch_en() ( ma_read_byte(10) & 0x02)>>1 
+#define set_obj_MA_ocp_latch_en(o, y)                \
+  ({                                                 \
+    uint8_t __ret = o.read(10);                      \
+    o.write(10, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_ocp_latch_en(y)                             \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(10);                      \
+    ma_write_byte(10, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_ocp_latch_en(o) (o.read(10) & 0x02) >> 1
+#define get_MA_ocp_latch_en() (ma_read_byte(10) & 0x02) >> 1
 //------------------------------------------------------------------------------lf_clamp_en---
-// High (default) to enable LF int2+3 clamping on clip 
+// High (default) to enable LF int2+3 clamping on clip
 #define MA_lf_clamp_en__a 10
 #define MA_lf_clamp_en__len 1
 #define MA_lf_clamp_en__mask 0x80
 #define MA_lf_clamp_en__shift 0x07
 #define MA_lf_clamp_en__reset 0x00
-#define set_obj_MA_lf_clamp_en(o,y) ({ uint8_t __ret = o.read(10); o.write(10,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_lf_clamp_en(y) ({ uint8_t __ret = ma_read_byte(10); ma_write_byte(10,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_lf_clamp_en(o) (o.read(10) & 0x80)>>7 
-#define get_MA_lf_clamp_en() ( ma_read_byte(10) & 0x80)>>7 
+#define set_obj_MA_lf_clamp_en(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(10);                      \
+    o.write(10, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_lf_clamp_en(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(10);                      \
+    ma_write_byte(10, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_lf_clamp_en(o) (o.read(10) & 0x80) >> 7
+#define get_MA_lf_clamp_en() (ma_read_byte(10) & 0x80) >> 7
 //------------------------------------------------------------------------------PMcfg_BTL_B.modType---
-//  
+//
 #define MA_PMcfg_BTL_B__modType__a 18
 #define MA_PMcfg_BTL_B__modType__len 2
 #define MA_PMcfg_BTL_B__modType__mask 0x18
 #define MA_PMcfg_BTL_B__modType__shift 0x03
 #define MA_PMcfg_BTL_B__modType__reset 0x02
-#define set_obj_MA_PMcfg_BTL_B__modType(o,y) ({ uint8_t __ret = o.read(18); o.write(18,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_BTL_B__modType(y) ({ uint8_t __ret = ma_read_byte(18); ma_write_byte(18,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_BTL_B__modType(o) (o.read(18) & 0x18)>>3 
-#define get_MA_PMcfg_BTL_B__modType() ( ma_read_byte(18) & 0x18)>>3 
+#define set_obj_MA_PMcfg_BTL_B__modType(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(18);                      \
+    o.write(18, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_BTL_B__modType(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(18);                      \
+    ma_write_byte(18, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_BTL_B__modType(o) (o.read(18) & 0x18) >> 3
+#define get_MA_PMcfg_BTL_B__modType() (ma_read_byte(18) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_BTL_B.freqDiv---
-//  
+//
 #define MA_PMcfg_BTL_B__freqDiv__a 18
 #define MA_PMcfg_BTL_B__freqDiv__len 2
 #define MA_PMcfg_BTL_B__freqDiv__mask 0x06
 #define MA_PMcfg_BTL_B__freqDiv__shift 0x01
 #define MA_PMcfg_BTL_B__freqDiv__reset 0x01
-#define set_obj_MA_PMcfg_BTL_B__freqDiv(o,y) ({ uint8_t __ret = o.read(18); o.write(18,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_BTL_B__freqDiv(y) ({ uint8_t __ret = ma_read_byte(18); ma_write_byte(18,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_BTL_B__freqDiv(o) (o.read(18) & 0x06)>>1 
-#define get_MA_PMcfg_BTL_B__freqDiv() ( ma_read_byte(18) & 0x06)>>1 
+#define set_obj_MA_PMcfg_BTL_B__freqDiv(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(18);                      \
+    o.write(18, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_BTL_B__freqDiv(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(18);                      \
+    ma_write_byte(18, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_BTL_B__freqDiv(o) (o.read(18) & 0x06) >> 1
+#define get_MA_PMcfg_BTL_B__freqDiv() (ma_read_byte(18) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_BTL_B.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_BTL_B__lf_gain_ol__a 18
 #define MA_PMcfg_BTL_B__lf_gain_ol__len 1
 #define MA_PMcfg_BTL_B__lf_gain_ol__mask 0x01
 #define MA_PMcfg_BTL_B__lf_gain_ol__shift 0x00
 #define MA_PMcfg_BTL_B__lf_gain_ol__reset 0x01
-#define set_obj_MA_PMcfg_BTL_B__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(18); o.write(18,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_BTL_B__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(18); ma_write_byte(18,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_BTL_B__lf_gain_ol(o) (o.read(18) & 0x01)>>0 
-#define get_MA_PMcfg_BTL_B__lf_gain_ol() ( ma_read_byte(18) & 0x01)>>0 
+#define set_obj_MA_PMcfg_BTL_B__lf_gain_ol(o, y)     \
+  ({                                                 \
+    uint8_t __ret = o.read(18);                      \
+    o.write(18, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_BTL_B__lf_gain_ol(y)                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(18);                      \
+    ma_write_byte(18, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_BTL_B__lf_gain_ol(o) (o.read(18) & 0x01) >> 0
+#define get_MA_PMcfg_BTL_B__lf_gain_ol() (ma_read_byte(18) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_BTL_C.freqDiv---
-//  
+//
 #define MA_PMcfg_BTL_C__freqDiv__a 19
 #define MA_PMcfg_BTL_C__freqDiv__len 2
 #define MA_PMcfg_BTL_C__freqDiv__mask 0x06
 #define MA_PMcfg_BTL_C__freqDiv__shift 0x01
 #define MA_PMcfg_BTL_C__freqDiv__reset 0x01
-#define set_obj_MA_PMcfg_BTL_C__freqDiv(o,y) ({ uint8_t __ret = o.read(19); o.write(19,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_BTL_C__freqDiv(y) ({ uint8_t __ret = ma_read_byte(19); ma_write_byte(19,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_BTL_C__freqDiv(o) (o.read(19) & 0x06)>>1 
-#define get_MA_PMcfg_BTL_C__freqDiv() ( ma_read_byte(19) & 0x06)>>1 
+#define set_obj_MA_PMcfg_BTL_C__freqDiv(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(19);                      \
+    o.write(19, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_BTL_C__freqDiv(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(19);                      \
+    ma_write_byte(19, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_BTL_C__freqDiv(o) (o.read(19) & 0x06) >> 1
+#define get_MA_PMcfg_BTL_C__freqDiv() (ma_read_byte(19) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_BTL_C.modType---
-//  
+//
 #define MA_PMcfg_BTL_C__modType__a 19
 #define MA_PMcfg_BTL_C__modType__len 2
 #define MA_PMcfg_BTL_C__modType__mask 0x18
 #define MA_PMcfg_BTL_C__modType__shift 0x03
 #define MA_PMcfg_BTL_C__modType__reset 0x01
-#define set_obj_MA_PMcfg_BTL_C__modType(o,y) ({ uint8_t __ret = o.read(19); o.write(19,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_BTL_C__modType(y) ({ uint8_t __ret = ma_read_byte(19); ma_write_byte(19,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_BTL_C__modType(o) (o.read(19) & 0x18)>>3 
-#define get_MA_PMcfg_BTL_C__modType() ( ma_read_byte(19) & 0x18)>>3 
+#define set_obj_MA_PMcfg_BTL_C__modType(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(19);                      \
+    o.write(19, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_BTL_C__modType(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(19);                      \
+    ma_write_byte(19, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_BTL_C__modType(o) (o.read(19) & 0x18) >> 3
+#define get_MA_PMcfg_BTL_C__modType() (ma_read_byte(19) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_BTL_C.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_BTL_C__lf_gain_ol__a 19
 #define MA_PMcfg_BTL_C__lf_gain_ol__len 1
 #define MA_PMcfg_BTL_C__lf_gain_ol__mask 0x01
 #define MA_PMcfg_BTL_C__lf_gain_ol__shift 0x00
 #define MA_PMcfg_BTL_C__lf_gain_ol__reset 0x00
-#define set_obj_MA_PMcfg_BTL_C__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(19); o.write(19,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_BTL_C__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(19); ma_write_byte(19,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_BTL_C__lf_gain_ol(o) (o.read(19) & 0x01)>>0 
-#define get_MA_PMcfg_BTL_C__lf_gain_ol() ( ma_read_byte(19) & 0x01)>>0 
+#define set_obj_MA_PMcfg_BTL_C__lf_gain_ol(o, y)     \
+  ({                                                 \
+    uint8_t __ret = o.read(19);                      \
+    o.write(19, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_BTL_C__lf_gain_ol(y)                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(19);                      \
+    ma_write_byte(19, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_BTL_C__lf_gain_ol(o) (o.read(19) & 0x01) >> 0
+#define get_MA_PMcfg_BTL_C__lf_gain_ol() (ma_read_byte(19) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_BTL_D.modType---
-//  
+//
 #define MA_PMcfg_BTL_D__modType__a 20
 #define MA_PMcfg_BTL_D__modType__len 2
 #define MA_PMcfg_BTL_D__modType__mask 0x18
 #define MA_PMcfg_BTL_D__modType__shift 0x03
 #define MA_PMcfg_BTL_D__modType__reset 0x02
-#define set_obj_MA_PMcfg_BTL_D__modType(o,y) ({ uint8_t __ret = o.read(20); o.write(20,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_BTL_D__modType(y) ({ uint8_t __ret = ma_read_byte(20); ma_write_byte(20,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_BTL_D__modType(o) (o.read(20) & 0x18)>>3 
-#define get_MA_PMcfg_BTL_D__modType() ( ma_read_byte(20) & 0x18)>>3 
+#define set_obj_MA_PMcfg_BTL_D__modType(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(20);                      \
+    o.write(20, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_BTL_D__modType(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(20);                      \
+    ma_write_byte(20, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_BTL_D__modType(o) (o.read(20) & 0x18) >> 3
+#define get_MA_PMcfg_BTL_D__modType() (ma_read_byte(20) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_BTL_D.freqDiv---
-//  
+//
 #define MA_PMcfg_BTL_D__freqDiv__a 20
 #define MA_PMcfg_BTL_D__freqDiv__len 2
 #define MA_PMcfg_BTL_D__freqDiv__mask 0x06
 #define MA_PMcfg_BTL_D__freqDiv__shift 0x01
 #define MA_PMcfg_BTL_D__freqDiv__reset 0x02
-#define set_obj_MA_PMcfg_BTL_D__freqDiv(o,y) ({ uint8_t __ret = o.read(20); o.write(20,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_BTL_D__freqDiv(y) ({ uint8_t __ret = ma_read_byte(20); ma_write_byte(20,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_BTL_D__freqDiv(o) (o.read(20) & 0x06)>>1 
-#define get_MA_PMcfg_BTL_D__freqDiv() ( ma_read_byte(20) & 0x06)>>1 
+#define set_obj_MA_PMcfg_BTL_D__freqDiv(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(20);                      \
+    o.write(20, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_BTL_D__freqDiv(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(20);                      \
+    ma_write_byte(20, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_BTL_D__freqDiv(o) (o.read(20) & 0x06) >> 1
+#define get_MA_PMcfg_BTL_D__freqDiv() (ma_read_byte(20) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_BTL_D.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_BTL_D__lf_gain_ol__a 20
 #define MA_PMcfg_BTL_D__lf_gain_ol__len 1
 #define MA_PMcfg_BTL_D__lf_gain_ol__mask 0x01
 #define MA_PMcfg_BTL_D__lf_gain_ol__shift 0x00
 #define MA_PMcfg_BTL_D__lf_gain_ol__reset 0x00
-#define set_obj_MA_PMcfg_BTL_D__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(20); o.write(20,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_BTL_D__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(20); ma_write_byte(20,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_BTL_D__lf_gain_ol(o) (o.read(20) & 0x01)>>0 
-#define get_MA_PMcfg_BTL_D__lf_gain_ol() ( ma_read_byte(20) & 0x01)>>0 
+#define set_obj_MA_PMcfg_BTL_D__lf_gain_ol(o, y)     \
+  ({                                                 \
+    uint8_t __ret = o.read(20);                      \
+    o.write(20, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_BTL_D__lf_gain_ol(y)                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(20);                      \
+    ma_write_byte(20, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_BTL_D__lf_gain_ol(o) (o.read(20) & 0x01) >> 0
+#define get_MA_PMcfg_BTL_D__lf_gain_ol() (ma_read_byte(20) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_SE_A.modType---
-//  
+//
 #define MA_PMcfg_SE_A__modType__a 21
 #define MA_PMcfg_SE_A__modType__len 2
 #define MA_PMcfg_SE_A__modType__mask 0x18
 #define MA_PMcfg_SE_A__modType__shift 0x03
 #define MA_PMcfg_SE_A__modType__reset 0x01
-#define set_obj_MA_PMcfg_SE_A__modType(o,y) ({ uint8_t __ret = o.read(21); o.write(21,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_SE_A__modType(y) ({ uint8_t __ret = ma_read_byte(21); ma_write_byte(21,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_SE_A__modType(o) (o.read(21) & 0x18)>>3 
-#define get_MA_PMcfg_SE_A__modType() ( ma_read_byte(21) & 0x18)>>3 
+#define set_obj_MA_PMcfg_SE_A__modType(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(21);                      \
+    o.write(21, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_SE_A__modType(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(21);                      \
+    ma_write_byte(21, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_SE_A__modType(o) (o.read(21) & 0x18) >> 3
+#define get_MA_PMcfg_SE_A__modType() (ma_read_byte(21) & 0x18) >> 3
 //------------------------------------------------------------------------------PMcfg_SE_A.freqDiv---
-//  
+//
 #define MA_PMcfg_SE_A__freqDiv__a 21
 #define MA_PMcfg_SE_A__freqDiv__len 2
 #define MA_PMcfg_SE_A__freqDiv__mask 0x06
 #define MA_PMcfg_SE_A__freqDiv__shift 0x01
 #define MA_PMcfg_SE_A__freqDiv__reset 0x00
-#define set_obj_MA_PMcfg_SE_A__freqDiv(o,y) ({ uint8_t __ret = o.read(21); o.write(21,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_SE_A__freqDiv(y) ({ uint8_t __ret = ma_read_byte(21); ma_write_byte(21,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_SE_A__freqDiv(o) (o.read(21) & 0x06)>>1 
-#define get_MA_PMcfg_SE_A__freqDiv() ( ma_read_byte(21) & 0x06)>>1 
+#define set_obj_MA_PMcfg_SE_A__freqDiv(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(21);                      \
+    o.write(21, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_SE_A__freqDiv(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(21);                      \
+    ma_write_byte(21, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_SE_A__freqDiv(o) (o.read(21) & 0x06) >> 1
+#define get_MA_PMcfg_SE_A__freqDiv() (ma_read_byte(21) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_SE_A.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_SE_A__lf_gain_ol__a 21
 #define MA_PMcfg_SE_A__lf_gain_ol__len 1
 #define MA_PMcfg_SE_A__lf_gain_ol__mask 0x01
 #define MA_PMcfg_SE_A__lf_gain_ol__shift 0x00
 #define MA_PMcfg_SE_A__lf_gain_ol__reset 0x01
-#define set_obj_MA_PMcfg_SE_A__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(21); o.write(21,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_SE_A__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(21); ma_write_byte(21,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_SE_A__lf_gain_ol(o) (o.read(21) & 0x01)>>0 
-#define get_MA_PMcfg_SE_A__lf_gain_ol() ( ma_read_byte(21) & 0x01)>>0 
+#define set_obj_MA_PMcfg_SE_A__lf_gain_ol(o, y)      \
+  ({                                                 \
+    uint8_t __ret = o.read(21);                      \
+    o.write(21, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_SE_A__lf_gain_ol(y)                   \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(21);                      \
+    ma_write_byte(21, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_SE_A__lf_gain_ol(o) (o.read(21) & 0x01) >> 0
+#define get_MA_PMcfg_SE_A__lf_gain_ol() (ma_read_byte(21) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_SE_B.lf_gain_ol---
-//  
+//
 #define MA_PMcfg_SE_B__lf_gain_ol__a 22
 #define MA_PMcfg_SE_B__lf_gain_ol__len 1
 #define MA_PMcfg_SE_B__lf_gain_ol__mask 0x01
 #define MA_PMcfg_SE_B__lf_gain_ol__shift 0x00
 #define MA_PMcfg_SE_B__lf_gain_ol__reset 0x00
-#define set_obj_MA_PMcfg_SE_B__lf_gain_ol(o,y) ({ uint8_t __ret = o.read(22); o.write(22,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_PMcfg_SE_B__lf_gain_ol(y) ({ uint8_t __ret = ma_read_byte(22); ma_write_byte(22,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_PMcfg_SE_B__lf_gain_ol(o) (o.read(22) & 0x01)>>0 
-#define get_MA_PMcfg_SE_B__lf_gain_ol() ( ma_read_byte(22) & 0x01)>>0 
+#define set_obj_MA_PMcfg_SE_B__lf_gain_ol(o, y)      \
+  ({                                                 \
+    uint8_t __ret = o.read(22);                      \
+    o.write(22, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_PMcfg_SE_B__lf_gain_ol(y)                   \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(22);                      \
+    ma_write_byte(22, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_PMcfg_SE_B__lf_gain_ol(o) (o.read(22) & 0x01) >> 0
+#define get_MA_PMcfg_SE_B__lf_gain_ol() (ma_read_byte(22) & 0x01) >> 0
 //------------------------------------------------------------------------------PMcfg_SE_B.freqDiv---
-//  
+//
 #define MA_PMcfg_SE_B__freqDiv__a 22
 #define MA_PMcfg_SE_B__freqDiv__len 2
 #define MA_PMcfg_SE_B__freqDiv__mask 0x06
 #define MA_PMcfg_SE_B__freqDiv__shift 0x01
 #define MA_PMcfg_SE_B__freqDiv__reset 0x01
-#define set_obj_MA_PMcfg_SE_B__freqDiv(o,y) ({ uint8_t __ret = o.read(22); o.write(22,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define set_MA_PMcfg_SE_B__freqDiv(y) ({ uint8_t __ret = ma_read_byte(22); ma_write_byte(22,(__ret&0xf9)|((y<<1)&0x06)); }) 
-#define get_obj_MA_PMcfg_SE_B__freqDiv(o) (o.read(22) & 0x06)>>1 
-#define get_MA_PMcfg_SE_B__freqDiv() ( ma_read_byte(22) & 0x06)>>1 
+#define set_obj_MA_PMcfg_SE_B__freqDiv(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(22);                      \
+    o.write(22, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define set_MA_PMcfg_SE_B__freqDiv(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(22);                      \
+    ma_write_byte(22, (__ret & 0xf9) | ((y << 1) & 0x06)); \
+  })
+#define get_obj_MA_PMcfg_SE_B__freqDiv(o) (o.read(22) & 0x06) >> 1
+#define get_MA_PMcfg_SE_B__freqDiv() (ma_read_byte(22) & 0x06) >> 1
 //------------------------------------------------------------------------------PMcfg_SE_B.modType---
-//  
+//
 #define MA_PMcfg_SE_B__modType__a 22
 #define MA_PMcfg_SE_B__modType__len 2
 #define MA_PMcfg_SE_B__modType__mask 0x18
 #define MA_PMcfg_SE_B__modType__shift 0x03
 #define MA_PMcfg_SE_B__modType__reset 0x01
-#define set_obj_MA_PMcfg_SE_B__modType(o,y) ({ uint8_t __ret = o.read(22); o.write(22,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_PMcfg_SE_B__modType(y) ({ uint8_t __ret = ma_read_byte(22); ma_write_byte(22,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_PMcfg_SE_B__modType(o) (o.read(22) & 0x18)>>3 
-#define get_MA_PMcfg_SE_B__modType() ( ma_read_byte(22) & 0x18)>>3 
+#define set_obj_MA_PMcfg_SE_B__modType(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(22);                      \
+    o.write(22, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_PMcfg_SE_B__modType(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(22);                      \
+    ma_write_byte(22, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_PMcfg_SE_B__modType(o) (o.read(22) & 0x18) >> 3
+#define get_MA_PMcfg_SE_B__modType() (ma_read_byte(22) & 0x18) >> 3
 //------------------------------------------------------------------------------balWaitCount_PM1---
-// PM1 balancing period. 
+// PM1 balancing period.
 #define MA_balWaitCount_PM1__a 23
 #define MA_balWaitCount_PM1__len 8
 #define MA_balWaitCount_PM1__mask 0xff
 #define MA_balWaitCount_PM1__shift 0x00
 #define MA_balWaitCount_PM1__reset 0x14
-#define set_obj_MA_balWaitCount_PM1(o,y) o.write(23,y);
-#define set_MA_balWaitCount_PM1(y) ma_write_byte(23,y);
-#define get_obj_MA_balWaitCount_PM1(o) (o.read(23) & 0xff)>>0 
-#define get_MA_balWaitCount_PM1() ( ma_read_byte(23) & 0xff)>>0 
+#define set_obj_MA_balWaitCount_PM1(o, y) o.write(23, y);
+#define set_MA_balWaitCount_PM1(y) ma_write_byte(23, y);
+#define get_obj_MA_balWaitCount_PM1(o) (o.read(23) & 0xff) >> 0
+#define get_MA_balWaitCount_PM1() (ma_read_byte(23) & 0xff) >> 0
 //------------------------------------------------------------------------------balWaitCount_PM2---
-// PM2 balancing period. 
+// PM2 balancing period.
 #define MA_balWaitCount_PM2__a 24
 #define MA_balWaitCount_PM2__len 8
 #define MA_balWaitCount_PM2__mask 0xff
 #define MA_balWaitCount_PM2__shift 0x00
 #define MA_balWaitCount_PM2__reset 0x14
-#define set_obj_MA_balWaitCount_PM2(o,y) o.write(24,y);
-#define set_MA_balWaitCount_PM2(y) ma_write_byte(24,y);
-#define get_obj_MA_balWaitCount_PM2(o) (o.read(24) & 0xff)>>0 
-#define get_MA_balWaitCount_PM2() ( ma_read_byte(24) & 0xff)>>0 
+#define set_obj_MA_balWaitCount_PM2(o, y) o.write(24, y);
+#define set_MA_balWaitCount_PM2(y) ma_write_byte(24, y);
+#define get_obj_MA_balWaitCount_PM2(o) (o.read(24) & 0xff) >> 0
+#define get_MA_balWaitCount_PM2() (ma_read_byte(24) & 0xff) >> 0
 //------------------------------------------------------------------------------balWaitCount_PM3---
-// PM3 balancing period. 
+// PM3 balancing period.
 #define MA_balWaitCount_PM3__a 25
 #define MA_balWaitCount_PM3__len 8
 #define MA_balWaitCount_PM3__mask 0xff
 #define MA_balWaitCount_PM3__shift 0x00
 #define MA_balWaitCount_PM3__reset 0x1a
-#define set_obj_MA_balWaitCount_PM3(o,y) o.write(25,y);
-#define set_MA_balWaitCount_PM3(y) ma_write_byte(25,y);
-#define get_obj_MA_balWaitCount_PM3(o) (o.read(25) & 0xff)>>0 
-#define get_MA_balWaitCount_PM3() ( ma_read_byte(25) & 0xff)>>0 
+#define set_obj_MA_balWaitCount_PM3(o, y) o.write(25, y);
+#define set_MA_balWaitCount_PM3(y) ma_write_byte(25, y);
+#define get_obj_MA_balWaitCount_PM3(o) (o.read(25) & 0xff) >> 0
+#define get_MA_balWaitCount_PM3() (ma_read_byte(25) & 0xff) >> 0
 //------------------------------------------------------------------------------useSpread_PM1---
-// PM1 PWM spread-spectrum mode on/off. 
+// PM1 PWM spread-spectrum mode on/off.
 #define MA_useSpread_PM1__a 26
 #define MA_useSpread_PM1__len 1
 #define MA_useSpread_PM1__mask 0x40
 #define MA_useSpread_PM1__shift 0x06
 #define MA_useSpread_PM1__reset 0x00
-#define set_obj_MA_useSpread_PM1(o,y) ({ uint8_t __ret = o.read(26); o.write(26,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_useSpread_PM1(y) ({ uint8_t __ret = ma_read_byte(26); ma_write_byte(26,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_useSpread_PM1(o) (o.read(26) & 0x40)>>6 
-#define get_MA_useSpread_PM1() ( ma_read_byte(26) & 0x40)>>6 
+#define set_obj_MA_useSpread_PM1(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(26);                      \
+    o.write(26, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_useSpread_PM1(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(26);                      \
+    ma_write_byte(26, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_useSpread_PM1(o) (o.read(26) & 0x40) >> 6
+#define get_MA_useSpread_PM1() (ma_read_byte(26) & 0x40) >> 6
 //------------------------------------------------------------------------------DTsteps_PM1---
-// PM1 dead time setting [10ns steps]. 
+// PM1 dead time setting [10ns steps].
 #define MA_DTsteps_PM1__a 26
 #define MA_DTsteps_PM1__len 3
 #define MA_DTsteps_PM1__mask 0x38
 #define MA_DTsteps_PM1__shift 0x03
 #define MA_DTsteps_PM1__reset 0x04
-#define set_obj_MA_DTsteps_PM1(o,y) ({ uint8_t __ret = o.read(26); o.write(26,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define set_MA_DTsteps_PM1(y) ({ uint8_t __ret = ma_read_byte(26); ma_write_byte(26,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define get_obj_MA_DTsteps_PM1(o) (o.read(26) & 0x38)>>3 
-#define get_MA_DTsteps_PM1() ( ma_read_byte(26) & 0x38)>>3 
+#define set_obj_MA_DTsteps_PM1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(26);                      \
+    o.write(26, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define set_MA_DTsteps_PM1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(26);                      \
+    ma_write_byte(26, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define get_obj_MA_DTsteps_PM1(o) (o.read(26) & 0x38) >> 3
+#define get_MA_DTsteps_PM1() (ma_read_byte(26) & 0x38) >> 3
 //------------------------------------------------------------------------------balType_PM1---
-// PM1 balancing sensor scheme. 
+// PM1 balancing sensor scheme.
 #define MA_balType_PM1__a 26
 #define MA_balType_PM1__len 3
 #define MA_balType_PM1__mask 0x07
 #define MA_balType_PM1__shift 0x00
 #define MA_balType_PM1__reset 0x00
-#define set_obj_MA_balType_PM1(o,y) ({ uint8_t __ret = o.read(26); o.write(26,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_balType_PM1(y) ({ uint8_t __ret = ma_read_byte(26); ma_write_byte(26,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_balType_PM1(o) (o.read(26) & 0x07)>>0 
-#define get_MA_balType_PM1() ( ma_read_byte(26) & 0x07)>>0 
+#define set_obj_MA_balType_PM1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(26);                      \
+    o.write(26, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_balType_PM1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(26);                      \
+    ma_write_byte(26, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_balType_PM1(o) (o.read(26) & 0x07) >> 0
+#define get_MA_balType_PM1() (ma_read_byte(26) & 0x07) >> 0
 //------------------------------------------------------------------------------useSpread_PM2---
-// PM2 PWM spread-spectrum mode on/off. 
+// PM2 PWM spread-spectrum mode on/off.
 #define MA_useSpread_PM2__a 27
 #define MA_useSpread_PM2__len 1
 #define MA_useSpread_PM2__mask 0x40
 #define MA_useSpread_PM2__shift 0x06
 #define MA_useSpread_PM2__reset 0x00
-#define set_obj_MA_useSpread_PM2(o,y) ({ uint8_t __ret = o.read(27); o.write(27,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_useSpread_PM2(y) ({ uint8_t __ret = ma_read_byte(27); ma_write_byte(27,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_useSpread_PM2(o) (o.read(27) & 0x40)>>6 
-#define get_MA_useSpread_PM2() ( ma_read_byte(27) & 0x40)>>6 
+#define set_obj_MA_useSpread_PM2(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(27);                      \
+    o.write(27, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_useSpread_PM2(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(27);                      \
+    ma_write_byte(27, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_useSpread_PM2(o) (o.read(27) & 0x40) >> 6
+#define get_MA_useSpread_PM2() (ma_read_byte(27) & 0x40) >> 6
 //------------------------------------------------------------------------------DTsteps_PM2---
-// PM2 dead time setting [10ns steps]. 
+// PM2 dead time setting [10ns steps].
 #define MA_DTsteps_PM2__a 27
 #define MA_DTsteps_PM2__len 3
 #define MA_DTsteps_PM2__mask 0x38
 #define MA_DTsteps_PM2__shift 0x03
 #define MA_DTsteps_PM2__reset 0x03
-#define set_obj_MA_DTsteps_PM2(o,y) ({ uint8_t __ret = o.read(27); o.write(27,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define set_MA_DTsteps_PM2(y) ({ uint8_t __ret = ma_read_byte(27); ma_write_byte(27,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define get_obj_MA_DTsteps_PM2(o) (o.read(27) & 0x38)>>3 
-#define get_MA_DTsteps_PM2() ( ma_read_byte(27) & 0x38)>>3 
+#define set_obj_MA_DTsteps_PM2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(27);                      \
+    o.write(27, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define set_MA_DTsteps_PM2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(27);                      \
+    ma_write_byte(27, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define get_obj_MA_DTsteps_PM2(o) (o.read(27) & 0x38) >> 3
+#define get_MA_DTsteps_PM2() (ma_read_byte(27) & 0x38) >> 3
 //------------------------------------------------------------------------------balType_PM2---
-// PM2 balancing sensor scheme. 
+// PM2 balancing sensor scheme.
 #define MA_balType_PM2__a 27
 #define MA_balType_PM2__len 3
 #define MA_balType_PM2__mask 0x07
 #define MA_balType_PM2__shift 0x00
 #define MA_balType_PM2__reset 0x01
-#define set_obj_MA_balType_PM2(o,y) ({ uint8_t __ret = o.read(27); o.write(27,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_balType_PM2(y) ({ uint8_t __ret = ma_read_byte(27); ma_write_byte(27,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_balType_PM2(o) (o.read(27) & 0x07)>>0 
-#define get_MA_balType_PM2() ( ma_read_byte(27) & 0x07)>>0 
+#define set_obj_MA_balType_PM2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(27);                      \
+    o.write(27, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_balType_PM2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(27);                      \
+    ma_write_byte(27, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_balType_PM2(o) (o.read(27) & 0x07) >> 0
+#define get_MA_balType_PM2() (ma_read_byte(27) & 0x07) >> 0
 //------------------------------------------------------------------------------useSpread_PM3---
-// PM3 PWM spread-spectrum mode on/off. 
+// PM3 PWM spread-spectrum mode on/off.
 #define MA_useSpread_PM3__a 28
 #define MA_useSpread_PM3__len 1
 #define MA_useSpread_PM3__mask 0x40
 #define MA_useSpread_PM3__shift 0x06
 #define MA_useSpread_PM3__reset 0x00
-#define set_obj_MA_useSpread_PM3(o,y) ({ uint8_t __ret = o.read(28); o.write(28,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_useSpread_PM3(y) ({ uint8_t __ret = ma_read_byte(28); ma_write_byte(28,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_useSpread_PM3(o) (o.read(28) & 0x40)>>6 
-#define get_MA_useSpread_PM3() ( ma_read_byte(28) & 0x40)>>6 
+#define set_obj_MA_useSpread_PM3(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(28);                      \
+    o.write(28, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_useSpread_PM3(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(28);                      \
+    ma_write_byte(28, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_useSpread_PM3(o) (o.read(28) & 0x40) >> 6
+#define get_MA_useSpread_PM3() (ma_read_byte(28) & 0x40) >> 6
 //------------------------------------------------------------------------------DTsteps_PM3---
-// PM3 dead time setting [10ns steps]. 
+// PM3 dead time setting [10ns steps].
 #define MA_DTsteps_PM3__a 28
 #define MA_DTsteps_PM3__len 3
 #define MA_DTsteps_PM3__mask 0x38
 #define MA_DTsteps_PM3__shift 0x03
 #define MA_DTsteps_PM3__reset 0x01
-#define set_obj_MA_DTsteps_PM3(o,y) ({ uint8_t __ret = o.read(28); o.write(28,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define set_MA_DTsteps_PM3(y) ({ uint8_t __ret = ma_read_byte(28); ma_write_byte(28,(__ret&0xc7)|((y<<3)&0x38)); }) 
-#define get_obj_MA_DTsteps_PM3(o) (o.read(28) & 0x38)>>3 
-#define get_MA_DTsteps_PM3() ( ma_read_byte(28) & 0x38)>>3 
+#define set_obj_MA_DTsteps_PM3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(28);                      \
+    o.write(28, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define set_MA_DTsteps_PM3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(28);                      \
+    ma_write_byte(28, (__ret & 0xc7) | ((y << 3) & 0x38)); \
+  })
+#define get_obj_MA_DTsteps_PM3(o) (o.read(28) & 0x38) >> 3
+#define get_MA_DTsteps_PM3() (ma_read_byte(28) & 0x38) >> 3
 //------------------------------------------------------------------------------balType_PM3---
-// PM3 balancing sensor scheme. 
+// PM3 balancing sensor scheme.
 #define MA_balType_PM3__a 28
 #define MA_balType_PM3__len 3
 #define MA_balType_PM3__mask 0x07
 #define MA_balType_PM3__shift 0x00
 #define MA_balType_PM3__reset 0x03
-#define set_obj_MA_balType_PM3(o,y) ({ uint8_t __ret = o.read(28); o.write(28,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_balType_PM3(y) ({ uint8_t __ret = ma_read_byte(28); ma_write_byte(28,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_balType_PM3(o) (o.read(28) & 0x07)>>0 
-#define get_MA_balType_PM3() ( ma_read_byte(28) & 0x07)>>0 
+#define set_obj_MA_balType_PM3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(28);                      \
+    o.write(28, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_balType_PM3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(28);                      \
+    ma_write_byte(28, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_balType_PM3(o) (o.read(28) & 0x07) >> 0
+#define get_MA_balType_PM3() (ma_read_byte(28) & 0x07) >> 0
 //------------------------------------------------------------------------------PMprofile---
-// PM profile select. Valid presets: 0-1-2-3-4. 5=> custom profile. 
+// PM profile select. Valid presets: 0-1-2-3-4. 5=> custom profile.
 #define MA_PMprofile__a 29
 #define MA_PMprofile__len 3
 #define MA_PMprofile__mask 0x07
 #define MA_PMprofile__shift 0x00
 #define MA_PMprofile__reset 0x00
-#define set_obj_MA_PMprofile(o,y) ({ uint8_t __ret = o.read(29); o.write(29,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_PMprofile(y) ({ uint8_t __ret = ma_read_byte(29); ma_write_byte(29,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_PMprofile(o) (o.read(29) & 0x07)>>0 
-#define get_MA_PMprofile() ( ma_read_byte(29) & 0x07)>>0 
+#define set_obj_MA_PMprofile(o, y)                   \
+  ({                                                 \
+    uint8_t __ret = o.read(29);                      \
+    o.write(29, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_PMprofile(y)                                \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(29);                      \
+    ma_write_byte(29, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_PMprofile(o) (o.read(29) & 0x07) >> 0
+#define get_MA_PMprofile() (ma_read_byte(29) & 0x07) >> 0
 //------------------------------------------------------------------------------PM3_man---
-// Custom profile PM3 contents. 0=>A, 1=>B, 2=>C, 3=>D 
+// Custom profile PM3 contents. 0=>A, 1=>B, 2=>C, 3=>D
 #define MA_PM3_man__a 30
 #define MA_PM3_man__len 2
 #define MA_PM3_man__mask 0x30
 #define MA_PM3_man__shift 0x04
 #define MA_PM3_man__reset 0x02
-#define set_obj_MA_PM3_man(o,y) ({ uint8_t __ret = o.read(30); o.write(30,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_PM3_man(y) ({ uint8_t __ret = ma_read_byte(30); ma_write_byte(30,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_PM3_man(o) (o.read(30) & 0x30)>>4 
-#define get_MA_PM3_man() ( ma_read_byte(30) & 0x30)>>4 
+#define set_obj_MA_PM3_man(o, y)                     \
+  ({                                                 \
+    uint8_t __ret = o.read(30);                      \
+    o.write(30, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_PM3_man(y)                                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(30);                      \
+    ma_write_byte(30, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_PM3_man(o) (o.read(30) & 0x30) >> 4
+#define get_MA_PM3_man() (ma_read_byte(30) & 0x30) >> 4
 //------------------------------------------------------------------------------PM2_man---
-// Custom profile PM2 contents. 0=>A, 1=>B, 2=>C, 3=>D 
+// Custom profile PM2 contents. 0=>A, 1=>B, 2=>C, 3=>D
 #define MA_PM2_man__a 30
 #define MA_PM2_man__len 2
 #define MA_PM2_man__mask 0x0c
 #define MA_PM2_man__shift 0x02
 #define MA_PM2_man__reset 0x03
-#define set_obj_MA_PM2_man(o,y) ({ uint8_t __ret = o.read(30); o.write(30,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define set_MA_PM2_man(y) ({ uint8_t __ret = ma_read_byte(30); ma_write_byte(30,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define get_obj_MA_PM2_man(o) (o.read(30) & 0x0c)>>2 
-#define get_MA_PM2_man() ( ma_read_byte(30) & 0x0c)>>2 
+#define set_obj_MA_PM2_man(o, y)                     \
+  ({                                                 \
+    uint8_t __ret = o.read(30);                      \
+    o.write(30, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define set_MA_PM2_man(y)                                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(30);                      \
+    ma_write_byte(30, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define get_obj_MA_PM2_man(o) (o.read(30) & 0x0c) >> 2
+#define get_MA_PM2_man() (ma_read_byte(30) & 0x0c) >> 2
 //------------------------------------------------------------------------------PM1_man---
-// Custom profile PM1 contents. 0=>A, 1=>B, 2=>C, 3=>D 
+// Custom profile PM1 contents. 0=>A, 1=>B, 2=>C, 3=>D
 #define MA_PM1_man__a 30
 #define MA_PM1_man__len 2
 #define MA_PM1_man__mask 0x03
 #define MA_PM1_man__shift 0x00
 #define MA_PM1_man__reset 0x03
-#define set_obj_MA_PM1_man(o,y) ({ uint8_t __ret = o.read(30); o.write(30,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_PM1_man(y) ({ uint8_t __ret = ma_read_byte(30); ma_write_byte(30,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_PM1_man(o) (o.read(30) & 0x03)>>0 
-#define get_MA_PM1_man() ( ma_read_byte(30) & 0x03)>>0 
+#define set_obj_MA_PM1_man(o, y)                     \
+  ({                                                 \
+    uint8_t __ret = o.read(30);                      \
+    o.write(30, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_PM1_man(y)                                  \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(30);                      \
+    ma_write_byte(30, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_PM1_man(o) (o.read(30) & 0x03) >> 0
+#define get_MA_PM1_man() (ma_read_byte(30) & 0x03) >> 0
 //------------------------------------------------------------------------------ocp_latch_clear---
-// Low-high clears current OCP latched condition. 
+// Low-high clears current OCP latched condition.
 #define MA_ocp_latch_clear__a 32
 #define MA_ocp_latch_clear__len 1
 #define MA_ocp_latch_clear__mask 0x80
 #define MA_ocp_latch_clear__shift 0x07
 #define MA_ocp_latch_clear__reset 0x00
-#define set_obj_MA_ocp_latch_clear(o,y) ({ uint8_t __ret = o.read(32); o.write(32,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_ocp_latch_clear(y) ({ uint8_t __ret = ma_read_byte(32); ma_write_byte(32,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_ocp_latch_clear(o) (o.read(32) & 0x80)>>7 
-#define get_MA_ocp_latch_clear() ( ma_read_byte(32) & 0x80)>>7 
+#define set_obj_MA_ocp_latch_clear(o, y)             \
+  ({                                                 \
+    uint8_t __ret = o.read(32);                      \
+    o.write(32, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_ocp_latch_clear(y)                          \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(32);                      \
+    ma_write_byte(32, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_ocp_latch_clear(o) (o.read(32) & 0x80) >> 7
+#define get_MA_ocp_latch_clear() (ma_read_byte(32) & 0x80) >> 7
 //------------------------------------------------------------------------------audio_in_mode---
-// Audio input mode; 0-1-2-3-4-5 
+// Audio input mode; 0-1-2-3-4-5
 #define MA_audio_in_mode__a 37
 #define MA_audio_in_mode__len 3
 #define MA_audio_in_mode__mask 0xe0
 #define MA_audio_in_mode__shift 0x05
 #define MA_audio_in_mode__reset 0x00
-#define set_obj_MA_audio_in_mode(o,y) ({ uint8_t __ret = o.read(37); o.write(37,(__ret&0x1f)|((y<<5)&0xe0)); }) 
-#define set_MA_audio_in_mode(y) ({ uint8_t __ret = ma_read_byte(37); ma_write_byte(37,(__ret&0x1f)|((y<<5)&0xe0)); }) 
-#define get_obj_MA_audio_in_mode(o) (o.read(37) & 0xe0)>>5 
-#define get_MA_audio_in_mode() ( ma_read_byte(37) & 0xe0)>>5 
+#define set_obj_MA_audio_in_mode(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(37);                      \
+    o.write(37, (__ret & 0x1f) | ((y << 5) & 0xe0)); \
+  })
+#define set_MA_audio_in_mode(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(37);                      \
+    ma_write_byte(37, (__ret & 0x1f) | ((y << 5) & 0xe0)); \
+  })
+#define get_obj_MA_audio_in_mode(o) (o.read(37) & 0xe0) >> 5
+#define get_MA_audio_in_mode() (ma_read_byte(37) & 0xe0) >> 5
 //------------------------------------------------------------------------------eh_dcShdn---
-// High to enable DC protection 
+// High to enable DC protection
 #define MA_eh_dcShdn__a 38
 #define MA_eh_dcShdn__len 1
 #define MA_eh_dcShdn__mask 0x04
 #define MA_eh_dcShdn__shift 0x02
 #define MA_eh_dcShdn__reset 0x01
-#define set_obj_MA_eh_dcShdn(o,y) ({ uint8_t __ret = o.read(38); o.write(38,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_eh_dcShdn(y) ({ uint8_t __ret = ma_read_byte(38); ma_write_byte(38,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_eh_dcShdn(o) (o.read(38) & 0x04)>>2 
-#define get_MA_eh_dcShdn() ( ma_read_byte(38) & 0x04)>>2 
+#define set_obj_MA_eh_dcShdn(o, y)                   \
+  ({                                                 \
+    uint8_t __ret = o.read(38);                      \
+    o.write(38, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_eh_dcShdn(y)                                \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(38);                      \
+    ma_write_byte(38, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_eh_dcShdn(o) (o.read(38) & 0x04) >> 2
+#define get_MA_eh_dcShdn() (ma_read_byte(38) & 0x04) >> 2
 //------------------------------------------------------------------------------audio_in_mode_ext---
-// If set, audio_in_mode is controlled from audio_in_mode register. If not set  audio_in_mode is set from fuse bank setting 
+// If set, audio_in_mode is controlled from audio_in_mode register. If not set
+// audio_in_mode is set from fuse bank setting
 #define MA_audio_in_mode_ext__a 39
 #define MA_audio_in_mode_ext__len 1
 #define MA_audio_in_mode_ext__mask 0x20
 #define MA_audio_in_mode_ext__shift 0x05
 #define MA_audio_in_mode_ext__reset 0x00
-#define set_obj_MA_audio_in_mode_ext(o,y) ({ uint8_t __ret = o.read(39); o.write(39,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_audio_in_mode_ext(y) ({ uint8_t __ret = ma_read_byte(39); ma_write_byte(39,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_audio_in_mode_ext(o) (o.read(39) & 0x20)>>5 
-#define get_MA_audio_in_mode_ext() ( ma_read_byte(39) & 0x20)>>5 
+#define set_obj_MA_audio_in_mode_ext(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(39);                      \
+    o.write(39, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_audio_in_mode_ext(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(39);                      \
+    ma_write_byte(39, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_audio_in_mode_ext(o) (o.read(39) & 0x20) >> 5
+#define get_MA_audio_in_mode_ext() (ma_read_byte(39) & 0x20) >> 5
 //------------------------------------------------------------------------------eh_clear---
-// Flip to clear error registers 
+// Flip to clear error registers
 #define MA_eh_clear__a 45
 #define MA_eh_clear__len 1
 #define MA_eh_clear__mask 0x04
 #define MA_eh_clear__shift 0x02
 #define MA_eh_clear__reset 0x00
-#define set_obj_MA_eh_clear(o,y) ({ uint8_t __ret = o.read(45); o.write(45,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_eh_clear(y) ({ uint8_t __ret = ma_read_byte(45); ma_write_byte(45,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_eh_clear(o) (o.read(45) & 0x04)>>2 
-#define get_MA_eh_clear() ( ma_read_byte(45) & 0x04)>>2 
+#define set_obj_MA_eh_clear(o, y)                    \
+  ({                                                 \
+    uint8_t __ret = o.read(45);                      \
+    o.write(45, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_eh_clear(y)                                 \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(45);                      \
+    ma_write_byte(45, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_eh_clear(o) (o.read(45) & 0x04) >> 2
+#define get_MA_eh_clear() (ma_read_byte(45) & 0x04) >> 2
 //------------------------------------------------------------------------------thermal_compr_en---
-// Enable otw-contr.  input compression? 
+// Enable otw-contr.  input compression?
 #define MA_thermal_compr_en__a 45
 #define MA_thermal_compr_en__len 1
 #define MA_thermal_compr_en__mask 0x20
 #define MA_thermal_compr_en__shift 0x05
 #define MA_thermal_compr_en__reset 0x01
-#define set_obj_MA_thermal_compr_en(o,y) ({ uint8_t __ret = o.read(45); o.write(45,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_thermal_compr_en(y) ({ uint8_t __ret = ma_read_byte(45); ma_write_byte(45,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_thermal_compr_en(o) (o.read(45) & 0x20)>>5 
-#define get_MA_thermal_compr_en() ( ma_read_byte(45) & 0x20)>>5 
+#define set_obj_MA_thermal_compr_en(o, y)            \
+  ({                                                 \
+    uint8_t __ret = o.read(45);                      \
+    o.write(45, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_thermal_compr_en(y)                         \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(45);                      \
+    ma_write_byte(45, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_thermal_compr_en(o) (o.read(45) & 0x20) >> 5
+#define get_MA_thermal_compr_en() (ma_read_byte(45) & 0x20) >> 5
 //------------------------------------------------------------------------------system_mute---
-// 1 = mute system, 0 = normal operation 
+// 1 = mute system, 0 = normal operation
 #define MA_system_mute__a 45
 #define MA_system_mute__len 1
 #define MA_system_mute__mask 0x40
 #define MA_system_mute__shift 0x06
 #define MA_system_mute__reset 0x00
-#define set_obj_MA_system_mute(o,y) ({ uint8_t __ret = o.read(45); o.write(45,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_system_mute(y) ({ uint8_t __ret = ma_read_byte(45); ma_write_byte(45,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_system_mute(o) (o.read(45) & 0x40)>>6 
-#define get_MA_system_mute() ( ma_read_byte(45) & 0x40)>>6 
+#define set_obj_MA_system_mute(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(45);                      \
+    o.write(45, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_system_mute(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(45);                      \
+    ma_write_byte(45, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_system_mute(o) (o.read(45) & 0x40) >> 6
+#define get_MA_system_mute() (ma_read_byte(45) & 0x40) >> 6
 //------------------------------------------------------------------------------thermal_compr_max_db---
-// Audio limiter max thermal reduction 
+// Audio limiter max thermal reduction
 #define MA_thermal_compr_max_db__a 46
 #define MA_thermal_compr_max_db__len 3
 #define MA_thermal_compr_max_db__mask 0x07
 #define MA_thermal_compr_max_db__shift 0x00
 #define MA_thermal_compr_max_db__reset 0x04
-#define set_obj_MA_thermal_compr_max_db(o,y) ({ uint8_t __ret = o.read(46); o.write(46,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_thermal_compr_max_db(y) ({ uint8_t __ret = ma_read_byte(46); ma_write_byte(46,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_thermal_compr_max_db(o) (o.read(46) & 0x07)>>0 
-#define get_MA_thermal_compr_max_db() ( ma_read_byte(46) & 0x07)>>0 
+#define set_obj_MA_thermal_compr_max_db(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(46);                      \
+    o.write(46, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_thermal_compr_max_db(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(46);                      \
+    ma_write_byte(46, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_thermal_compr_max_db(o) (o.read(46) & 0x07) >> 0
+#define get_MA_thermal_compr_max_db() (ma_read_byte(46) & 0x07) >> 0
 //------------------------------------------------------------------------------audio_proc_enable---
-// Enable Audio proc, bypass if not enabled 
+// Enable Audio proc, bypass if not enabled
 #define MA_audio_proc_enable__a 53
 #define MA_audio_proc_enable__len 1
 #define MA_audio_proc_enable__mask 0x08
 #define MA_audio_proc_enable__shift 0x03
 #define MA_audio_proc_enable__reset 0x00
-#define set_obj_MA_audio_proc_enable(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define set_MA_audio_proc_enable(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define get_obj_MA_audio_proc_enable(o) (o.read(53) & 0x08)>>3 
-#define get_MA_audio_proc_enable() ( ma_read_byte(53) & 0x08)>>3 
+#define set_obj_MA_audio_proc_enable(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define set_MA_audio_proc_enable(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define get_obj_MA_audio_proc_enable(o) (o.read(53) & 0x08) >> 3
+#define get_MA_audio_proc_enable() (ma_read_byte(53) & 0x08) >> 3
 //------------------------------------------------------------------------------audio_proc_release---
-// 00:slow, 01:normal, 10:fast 
+// 00:slow, 01:normal, 10:fast
 #define MA_audio_proc_release__a 53
 #define MA_audio_proc_release__len 2
 #define MA_audio_proc_release__mask 0x30
 #define MA_audio_proc_release__shift 0x04
 #define MA_audio_proc_release__reset 0x00
-#define set_obj_MA_audio_proc_release(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_audio_proc_release(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_audio_proc_release(o) (o.read(53) & 0x30)>>4 
-#define get_MA_audio_proc_release() ( ma_read_byte(53) & 0x30)>>4 
+#define set_obj_MA_audio_proc_release(o, y)          \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_audio_proc_release(y)                       \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_audio_proc_release(o) (o.read(53) & 0x30) >> 4
+#define get_MA_audio_proc_release() (ma_read_byte(53) & 0x30) >> 4
 //------------------------------------------------------------------------------audio_proc_attack---
-// 00:slow, 01:normal, 10:fast  
+// 00:slow, 01:normal, 10:fast
 #define MA_audio_proc_attack__a 53
 #define MA_audio_proc_attack__len 2
 #define MA_audio_proc_attack__mask 0xc0
 #define MA_audio_proc_attack__shift 0x06
 #define MA_audio_proc_attack__reset 0x00
-#define set_obj_MA_audio_proc_attack(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define set_MA_audio_proc_attack(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define get_obj_MA_audio_proc_attack(o) (o.read(53) & 0xc0)>>6 
-#define get_MA_audio_proc_attack() ( ma_read_byte(53) & 0xc0)>>6 
+#define set_obj_MA_audio_proc_attack(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define set_MA_audio_proc_attack(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define get_obj_MA_audio_proc_attack(o) (o.read(53) & 0xc0) >> 6
+#define get_MA_audio_proc_attack() (ma_read_byte(53) & 0xc0) >> 6
 //------------------------------------------------------------------------------i2s_format---
-// i2s basic data format, 000 = std. i2s, 001 = left justified (default) 
+// i2s basic data format, 000 = std. i2s, 001 = left justified (default)
 #define MA_i2s_format__a 53
 #define MA_i2s_format__len 3
 #define MA_i2s_format__mask 0x07
 #define MA_i2s_format__shift 0x00
 #define MA_i2s_format__reset 0x01
-#define set_obj_MA_i2s_format(o,y) ({ uint8_t __ret = o.read(53); o.write(53,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_i2s_format(y) ({ uint8_t __ret = ma_read_byte(53); ma_write_byte(53,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_i2s_format(o) (o.read(53) & 0x07)>>0 
-#define get_MA_i2s_format() ( ma_read_byte(53) & 0x07)>>0 
+#define set_obj_MA_i2s_format(o, y)                  \
+  ({                                                 \
+    uint8_t __ret = o.read(53);                      \
+    o.write(53, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_i2s_format(y)                               \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(53);                      \
+    ma_write_byte(53, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_i2s_format(o) (o.read(53) & 0x07) >> 0
+#define get_MA_i2s_format() (ma_read_byte(53) & 0x07) >> 0
 //------------------------------------------------------------------------------audio_proc_limiterEnable---
-// 1: enable limiter, 0: disable limiter 
+// 1: enable limiter, 0: disable limiter
 #define MA_audio_proc_limiterEnable__a 54
 #define MA_audio_proc_limiterEnable__len 1
 #define MA_audio_proc_limiterEnable__mask 0x40
 #define MA_audio_proc_limiterEnable__shift 0x06
 #define MA_audio_proc_limiterEnable__reset 0x00
-#define set_obj_MA_audio_proc_limiterEnable(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_audio_proc_limiterEnable(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_audio_proc_limiterEnable(o) (o.read(54) & 0x40)>>6 
-#define get_MA_audio_proc_limiterEnable() ( ma_read_byte(54) & 0x40)>>6 
+#define set_obj_MA_audio_proc_limiterEnable(o, y)    \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_audio_proc_limiterEnable(y)                 \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_audio_proc_limiterEnable(o) (o.read(54) & 0x40) >> 6
+#define get_MA_audio_proc_limiterEnable() (ma_read_byte(54) & 0x40) >> 6
 //------------------------------------------------------------------------------audio_proc_mute---
-// 1: mute, 0: unmute 
+// 1: mute, 0: unmute
 #define MA_audio_proc_mute__a 54
 #define MA_audio_proc_mute__len 1
 #define MA_audio_proc_mute__mask 0x80
 #define MA_audio_proc_mute__shift 0x07
 #define MA_audio_proc_mute__reset 0x00
-#define set_obj_MA_audio_proc_mute(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_audio_proc_mute(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_audio_proc_mute(o) (o.read(54) & 0x80)>>7 
-#define get_MA_audio_proc_mute() ( ma_read_byte(54) & 0x80)>>7 
+#define set_obj_MA_audio_proc_mute(o, y)             \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_audio_proc_mute(y)                          \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_audio_proc_mute(o) (o.read(54) & 0x80) >> 7
+#define get_MA_audio_proc_mute() (ma_read_byte(54) & 0x80) >> 7
 //------------------------------------------------------------------------------i2s_sck_pol---
-// i2s sck polarity cfg. 0 = rising edge data change 
+// i2s sck polarity cfg. 0 = rising edge data change
 #define MA_i2s_sck_pol__a 54
 #define MA_i2s_sck_pol__len 1
 #define MA_i2s_sck_pol__mask 0x01
 #define MA_i2s_sck_pol__shift 0x00
 #define MA_i2s_sck_pol__reset 0x01
-#define set_obj_MA_i2s_sck_pol(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_i2s_sck_pol(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_i2s_sck_pol(o) (o.read(54) & 0x01)>>0 
-#define get_MA_i2s_sck_pol() ( ma_read_byte(54) & 0x01)>>0 
+#define set_obj_MA_i2s_sck_pol(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_i2s_sck_pol(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_i2s_sck_pol(o) (o.read(54) & 0x01) >> 0
+#define get_MA_i2s_sck_pol() (ma_read_byte(54) & 0x01) >> 0
 //------------------------------------------------------------------------------i2s_framesize---
-// i2s word length. 00 = 32bit, 01 = 24bit 
+// i2s word length. 00 = 32bit, 01 = 24bit
 #define MA_i2s_framesize__a 54
 #define MA_i2s_framesize__len 2
 #define MA_i2s_framesize__mask 0x18
 #define MA_i2s_framesize__shift 0x03
 #define MA_i2s_framesize__reset 0x00
-#define set_obj_MA_i2s_framesize(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define set_MA_i2s_framesize(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xe7)|((y<<3)&0x18)); }) 
-#define get_obj_MA_i2s_framesize(o) (o.read(54) & 0x18)>>3 
-#define get_MA_i2s_framesize() ( ma_read_byte(54) & 0x18)>>3 
+#define set_obj_MA_i2s_framesize(o, y)               \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define set_MA_i2s_framesize(y)                            \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xe7) | ((y << 3) & 0x18)); \
+  })
+#define get_obj_MA_i2s_framesize(o) (o.read(54) & 0x18) >> 3
+#define get_MA_i2s_framesize() (ma_read_byte(54) & 0x18) >> 3
 //------------------------------------------------------------------------------i2s_ws_pol---
-// i2s ws polarity. 0 = low first 
+// i2s ws polarity. 0 = low first
 #define MA_i2s_ws_pol__a 54
 #define MA_i2s_ws_pol__len 1
 #define MA_i2s_ws_pol__mask 0x02
 #define MA_i2s_ws_pol__shift 0x01
 #define MA_i2s_ws_pol__reset 0x00
-#define set_obj_MA_i2s_ws_pol(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_i2s_ws_pol(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_i2s_ws_pol(o) (o.read(54) & 0x02)>>1 
-#define get_MA_i2s_ws_pol() ( ma_read_byte(54) & 0x02)>>1 
+#define set_obj_MA_i2s_ws_pol(o, y)                  \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_i2s_ws_pol(y)                               \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_i2s_ws_pol(o) (o.read(54) & 0x02) >> 1
+#define get_MA_i2s_ws_pol() (ma_read_byte(54) & 0x02) >> 1
 //------------------------------------------------------------------------------i2s_order---
-// i2s word bit order. 0 = MSB first 
+// i2s word bit order. 0 = MSB first
 #define MA_i2s_order__a 54
 #define MA_i2s_order__len 1
 #define MA_i2s_order__mask 0x04
 #define MA_i2s_order__shift 0x02
 #define MA_i2s_order__reset 0x00
-#define set_obj_MA_i2s_order(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_i2s_order(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_i2s_order(o) (o.read(54) & 0x04)>>2 
-#define get_MA_i2s_order() ( ma_read_byte(54) & 0x04)>>2 
+#define set_obj_MA_i2s_order(o, y)                   \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_i2s_order(y)                                \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_i2s_order(o) (o.read(54) & 0x04) >> 2
+#define get_MA_i2s_order() (ma_read_byte(54) & 0x04) >> 2
 //------------------------------------------------------------------------------i2s_rightfirst---
-// i2s L/R word order; 0 = left first 
+// i2s L/R word order; 0 = left first
 #define MA_i2s_rightfirst__a 54
 #define MA_i2s_rightfirst__len 1
 #define MA_i2s_rightfirst__mask 0x20
 #define MA_i2s_rightfirst__shift 0x05
 #define MA_i2s_rightfirst__reset 0x00
-#define set_obj_MA_i2s_rightfirst(o,y) ({ uint8_t __ret = o.read(54); o.write(54,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_i2s_rightfirst(y) ({ uint8_t __ret = ma_read_byte(54); ma_write_byte(54,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_i2s_rightfirst(o) (o.read(54) & 0x20)>>5 
-#define get_MA_i2s_rightfirst() ( ma_read_byte(54) & 0x20)>>5 
+#define set_obj_MA_i2s_rightfirst(o, y)              \
+  ({                                                 \
+    uint8_t __ret = o.read(54);                      \
+    o.write(54, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_i2s_rightfirst(y)                           \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(54);                      \
+    ma_write_byte(54, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_i2s_rightfirst(o) (o.read(54) & 0x20) >> 5
+#define get_MA_i2s_rightfirst() (ma_read_byte(54) & 0x20) >> 5
 //------------------------------------------------------------------------------vol_db_master---
-// Master volume db 
+// Master volume db
 #define MA_vol_db_master__a 64
 #define MA_vol_db_master__len 8
 #define MA_vol_db_master__mask 0xff
 #define MA_vol_db_master__shift 0x00
 #define MA_vol_db_master__reset 0x18
-#define set_obj_MA_vol_db_master(o,y) o.write(64,y);
-#define set_MA_vol_db_master(y) ma_write_byte(64,y);
-#define get_obj_MA_vol_db_master(o) (o.read(64) & 0xff)>>0 
-#define get_MA_vol_db_master() ( ma_read_byte(64) & 0xff)>>0 
+#define set_obj_MA_vol_db_master(o, y) o.write(64, y);
+#define set_MA_vol_db_master(y) ma_write_byte(64, y);
+#define get_obj_MA_vol_db_master(o) (o.read(64) & 0xff) >> 0
+#define get_MA_vol_db_master() (ma_read_byte(64) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_lsb_master---
-// Master volume lsb 1/4 steps 
+// Master volume lsb 1/4 steps
 #define MA_vol_lsb_master__a 65
 #define MA_vol_lsb_master__len 2
 #define MA_vol_lsb_master__mask 0x03
 #define MA_vol_lsb_master__shift 0x00
 #define MA_vol_lsb_master__reset 0x00
-#define set_obj_MA_vol_lsb_master(o,y) ({ uint8_t __ret = o.read(65); o.write(65,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_vol_lsb_master(y) ({ uint8_t __ret = ma_read_byte(65); ma_write_byte(65,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_vol_lsb_master(o) (o.read(65) & 0x03)>>0 
-#define get_MA_vol_lsb_master() ( ma_read_byte(65) & 0x03)>>0 
+#define set_obj_MA_vol_lsb_master(o, y)              \
+  ({                                                 \
+    uint8_t __ret = o.read(65);                      \
+    o.write(65, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_vol_lsb_master(y)                           \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(65);                      \
+    ma_write_byte(65, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_vol_lsb_master(o) (o.read(65) & 0x03) >> 0
+#define get_MA_vol_lsb_master() (ma_read_byte(65) & 0x03) >> 0
 //------------------------------------------------------------------------------vol_db_ch0---
-// Volume channel 0 
+// Volume channel 0
 #define MA_vol_db_ch0__a 66
 #define MA_vol_db_ch0__len 8
 #define MA_vol_db_ch0__mask 0xff
 #define MA_vol_db_ch0__shift 0x00
 #define MA_vol_db_ch0__reset 0x18
-#define set_obj_MA_vol_db_ch0(o,y) o.write(66,y);
-#define set_MA_vol_db_ch0(y) ma_write_byte(66,y);
-#define get_obj_MA_vol_db_ch0(o) (o.read(66) & 0xff)>>0 
-#define get_MA_vol_db_ch0() ( ma_read_byte(66) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch0(o, y) o.write(66, y);
+#define set_MA_vol_db_ch0(y) ma_write_byte(66, y);
+#define get_obj_MA_vol_db_ch0(o) (o.read(66) & 0xff) >> 0
+#define get_MA_vol_db_ch0() (ma_read_byte(66) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_db_ch1---
-// Volume channel 1 
+// Volume channel 1
 #define MA_vol_db_ch1__a 67
 #define MA_vol_db_ch1__len 8
 #define MA_vol_db_ch1__mask 0xff
 #define MA_vol_db_ch1__shift 0x00
 #define MA_vol_db_ch1__reset 0x18
-#define set_obj_MA_vol_db_ch1(o,y) o.write(67,y);
-#define set_MA_vol_db_ch1(y) ma_write_byte(67,y);
-#define get_obj_MA_vol_db_ch1(o) (o.read(67) & 0xff)>>0 
-#define get_MA_vol_db_ch1() ( ma_read_byte(67) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch1(o, y) o.write(67, y);
+#define set_MA_vol_db_ch1(y) ma_write_byte(67, y);
+#define get_obj_MA_vol_db_ch1(o) (o.read(67) & 0xff) >> 0
+#define get_MA_vol_db_ch1() (ma_read_byte(67) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_db_ch2---
-// Volume channel 2 
+// Volume channel 2
 #define MA_vol_db_ch2__a 68
 #define MA_vol_db_ch2__len 8
 #define MA_vol_db_ch2__mask 0xff
 #define MA_vol_db_ch2__shift 0x00
 #define MA_vol_db_ch2__reset 0x18
-#define set_obj_MA_vol_db_ch2(o,y) o.write(68,y);
-#define set_MA_vol_db_ch2(y) ma_write_byte(68,y);
-#define get_obj_MA_vol_db_ch2(o) (o.read(68) & 0xff)>>0 
-#define get_MA_vol_db_ch2() ( ma_read_byte(68) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch2(o, y) o.write(68, y);
+#define set_MA_vol_db_ch2(y) ma_write_byte(68, y);
+#define get_obj_MA_vol_db_ch2(o) (o.read(68) & 0xff) >> 0
+#define get_MA_vol_db_ch2() (ma_read_byte(68) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_db_ch3---
-// Volume channel 3 
+// Volume channel 3
 #define MA_vol_db_ch3__a 69
 #define MA_vol_db_ch3__len 8
 #define MA_vol_db_ch3__mask 0xff
 #define MA_vol_db_ch3__shift 0x00
 #define MA_vol_db_ch3__reset 0x18
-#define set_obj_MA_vol_db_ch3(o,y) o.write(69,y);
-#define set_MA_vol_db_ch3(y) ma_write_byte(69,y);
-#define get_obj_MA_vol_db_ch3(o) (o.read(69) & 0xff)>>0 
-#define get_MA_vol_db_ch3() ( ma_read_byte(69) & 0xff)>>0 
+#define set_obj_MA_vol_db_ch3(o, y) o.write(69, y);
+#define set_MA_vol_db_ch3(y) ma_write_byte(69, y);
+#define get_obj_MA_vol_db_ch3(o) (o.read(69) & 0xff) >> 0
+#define get_MA_vol_db_ch3() (ma_read_byte(69) & 0xff) >> 0
 //------------------------------------------------------------------------------vol_lsb_ch0---
-// volume channel 1 - 1/4 steps 
+// volume channel 1 - 1/4 steps
 #define MA_vol_lsb_ch0__a 70
 #define MA_vol_lsb_ch0__len 2
 #define MA_vol_lsb_ch0__mask 0x03
 #define MA_vol_lsb_ch0__shift 0x00
 #define MA_vol_lsb_ch0__reset 0x00
-#define set_obj_MA_vol_lsb_ch0(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_vol_lsb_ch0(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_vol_lsb_ch0(o) (o.read(70) & 0x03)>>0 
-#define get_MA_vol_lsb_ch0() ( ma_read_byte(70) & 0x03)>>0 
+#define set_obj_MA_vol_lsb_ch0(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_vol_lsb_ch0(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_vol_lsb_ch0(o) (o.read(70) & 0x03) >> 0
+#define get_MA_vol_lsb_ch0() (ma_read_byte(70) & 0x03) >> 0
 //------------------------------------------------------------------------------vol_lsb_ch1---
-// volume channel 3 - 1/4 steps 
+// volume channel 3 - 1/4 steps
 #define MA_vol_lsb_ch1__a 70
 #define MA_vol_lsb_ch1__len 2
 #define MA_vol_lsb_ch1__mask 0x0c
 #define MA_vol_lsb_ch1__shift 0x02
 #define MA_vol_lsb_ch1__reset 0x00
-#define set_obj_MA_vol_lsb_ch1(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define set_MA_vol_lsb_ch1(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define get_obj_MA_vol_lsb_ch1(o) (o.read(70) & 0x0c)>>2 
-#define get_MA_vol_lsb_ch1() ( ma_read_byte(70) & 0x0c)>>2 
+#define set_obj_MA_vol_lsb_ch1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define set_MA_vol_lsb_ch1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define get_obj_MA_vol_lsb_ch1(o) (o.read(70) & 0x0c) >> 2
+#define get_MA_vol_lsb_ch1() (ma_read_byte(70) & 0x0c) >> 2
 //------------------------------------------------------------------------------vol_lsb_ch2---
-// volume channel 2 - 1/4 steps 
+// volume channel 2 - 1/4 steps
 #define MA_vol_lsb_ch2__a 70
 #define MA_vol_lsb_ch2__len 2
 #define MA_vol_lsb_ch2__mask 0x30
 #define MA_vol_lsb_ch2__shift 0x04
 #define MA_vol_lsb_ch2__reset 0x00
-#define set_obj_MA_vol_lsb_ch2(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_vol_lsb_ch2(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_vol_lsb_ch2(o) (o.read(70) & 0x30)>>4 
-#define get_MA_vol_lsb_ch2() ( ma_read_byte(70) & 0x30)>>4 
+#define set_obj_MA_vol_lsb_ch2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_vol_lsb_ch2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_vol_lsb_ch2(o) (o.read(70) & 0x30) >> 4
+#define get_MA_vol_lsb_ch2() (ma_read_byte(70) & 0x30) >> 4
 //------------------------------------------------------------------------------vol_lsb_ch3---
-// volume channel 3 - 1/4 steps 
+// volume channel 3 - 1/4 steps
 #define MA_vol_lsb_ch3__a 70
 #define MA_vol_lsb_ch3__len 2
 #define MA_vol_lsb_ch3__mask 0xc0
 #define MA_vol_lsb_ch3__shift 0x06
 #define MA_vol_lsb_ch3__reset 0x00
-#define set_obj_MA_vol_lsb_ch3(o,y) ({ uint8_t __ret = o.read(70); o.write(70,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define set_MA_vol_lsb_ch3(y) ({ uint8_t __ret = ma_read_byte(70); ma_write_byte(70,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define get_obj_MA_vol_lsb_ch3(o) (o.read(70) & 0xc0)>>6 
-#define get_MA_vol_lsb_ch3() ( ma_read_byte(70) & 0xc0)>>6 
+#define set_obj_MA_vol_lsb_ch3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(70);                      \
+    o.write(70, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define set_MA_vol_lsb_ch3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(70);                      \
+    ma_write_byte(70, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define get_obj_MA_vol_lsb_ch3(o) (o.read(70) & 0xc0) >> 6
+#define get_MA_vol_lsb_ch3() (ma_read_byte(70) & 0xc0) >> 6
 //------------------------------------------------------------------------------thr_db_ch0---
-// thr_db channel 0 
+// thr_db channel 0
 #define MA_thr_db_ch0__a 71
 #define MA_thr_db_ch0__len 8
 #define MA_thr_db_ch0__mask 0xff
 #define MA_thr_db_ch0__shift 0x00
 #define MA_thr_db_ch0__reset 0x18
-#define set_obj_MA_thr_db_ch0(o,y) o.write(71,y);
-#define set_MA_thr_db_ch0(y) ma_write_byte(71,y);
-#define get_obj_MA_thr_db_ch0(o) (o.read(71) & 0xff)>>0 
-#define get_MA_thr_db_ch0() ( ma_read_byte(71) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch0(o, y) o.write(71, y);
+#define set_MA_thr_db_ch0(y) ma_write_byte(71, y);
+#define get_obj_MA_thr_db_ch0(o) (o.read(71) & 0xff) >> 0
+#define get_MA_thr_db_ch0() (ma_read_byte(71) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_db_ch1---
-// Thr db ch1 
+// Thr db ch1
 #define MA_thr_db_ch1__a 72
 #define MA_thr_db_ch1__len 8
 #define MA_thr_db_ch1__mask 0xff
 #define MA_thr_db_ch1__shift 0x00
 #define MA_thr_db_ch1__reset 0x18
-#define set_obj_MA_thr_db_ch1(o,y) o.write(72,y);
-#define set_MA_thr_db_ch1(y) ma_write_byte(72,y);
-#define get_obj_MA_thr_db_ch1(o) (o.read(72) & 0xff)>>0 
-#define get_MA_thr_db_ch1() ( ma_read_byte(72) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch1(o, y) o.write(72, y);
+#define set_MA_thr_db_ch1(y) ma_write_byte(72, y);
+#define get_obj_MA_thr_db_ch1(o) (o.read(72) & 0xff) >> 0
+#define get_MA_thr_db_ch1() (ma_read_byte(72) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_db_ch2---
-// thr db ch2 
+// thr db ch2
 #define MA_thr_db_ch2__a 73
 #define MA_thr_db_ch2__len 8
 #define MA_thr_db_ch2__mask 0xff
 #define MA_thr_db_ch2__shift 0x00
 #define MA_thr_db_ch2__reset 0x18
-#define set_obj_MA_thr_db_ch2(o,y) o.write(73,y);
-#define set_MA_thr_db_ch2(y) ma_write_byte(73,y);
-#define get_obj_MA_thr_db_ch2(o) (o.read(73) & 0xff)>>0 
-#define get_MA_thr_db_ch2() ( ma_read_byte(73) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch2(o, y) o.write(73, y);
+#define set_MA_thr_db_ch2(y) ma_write_byte(73, y);
+#define get_obj_MA_thr_db_ch2(o) (o.read(73) & 0xff) >> 0
+#define get_MA_thr_db_ch2() (ma_read_byte(73) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_db_ch3---
-// Threshold db ch3   
+// Threshold db ch3
 #define MA_thr_db_ch3__a 74
 #define MA_thr_db_ch3__len 8
 #define MA_thr_db_ch3__mask 0xff
 #define MA_thr_db_ch3__shift 0x00
 #define MA_thr_db_ch3__reset 0x18
-#define set_obj_MA_thr_db_ch3(o,y) o.write(74,y);
-#define set_MA_thr_db_ch3(y) ma_write_byte(74,y);
-#define get_obj_MA_thr_db_ch3(o) (o.read(74) & 0xff)>>0 
-#define get_MA_thr_db_ch3() ( ma_read_byte(74) & 0xff)>>0 
+#define set_obj_MA_thr_db_ch3(o, y) o.write(74, y);
+#define set_MA_thr_db_ch3(y) ma_write_byte(74, y);
+#define get_obj_MA_thr_db_ch3(o) (o.read(74) & 0xff) >> 0
+#define get_MA_thr_db_ch3() (ma_read_byte(74) & 0xff) >> 0
 //------------------------------------------------------------------------------thr_lsb_ch0---
-// Thr lsb ch0 
+// Thr lsb ch0
 #define MA_thr_lsb_ch0__a 75
 #define MA_thr_lsb_ch0__len 2
 #define MA_thr_lsb_ch0__mask 0x03
 #define MA_thr_lsb_ch0__shift 0x00
 #define MA_thr_lsb_ch0__reset 0x00
-#define set_obj_MA_thr_lsb_ch0(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_thr_lsb_ch0(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_thr_lsb_ch0(o) (o.read(75) & 0x03)>>0 
-#define get_MA_thr_lsb_ch0() ( ma_read_byte(75) & 0x03)>>0 
+#define set_obj_MA_thr_lsb_ch0(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_thr_lsb_ch0(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_thr_lsb_ch0(o) (o.read(75) & 0x03) >> 0
+#define get_MA_thr_lsb_ch0() (ma_read_byte(75) & 0x03) >> 0
 //------------------------------------------------------------------------------thr_lsb_ch1---
-// thr lsb ch1 
+// thr lsb ch1
 #define MA_thr_lsb_ch1__a 75
 #define MA_thr_lsb_ch1__len 2
 #define MA_thr_lsb_ch1__mask 0x0c
 #define MA_thr_lsb_ch1__shift 0x02
 #define MA_thr_lsb_ch1__reset 0x00
-#define set_obj_MA_thr_lsb_ch1(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define set_MA_thr_lsb_ch1(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0xf3)|((y<<2)&0x0c)); }) 
-#define get_obj_MA_thr_lsb_ch1(o) (o.read(75) & 0x0c)>>2 
-#define get_MA_thr_lsb_ch1() ( ma_read_byte(75) & 0x0c)>>2 
+#define set_obj_MA_thr_lsb_ch1(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define set_MA_thr_lsb_ch1(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0xf3) | ((y << 2) & 0x0c)); \
+  })
+#define get_obj_MA_thr_lsb_ch1(o) (o.read(75) & 0x0c) >> 2
+#define get_MA_thr_lsb_ch1() (ma_read_byte(75) & 0x0c) >> 2
 //------------------------------------------------------------------------------thr_lsb_ch2---
-// thr lsb ch2 1/4 db step 
+// thr lsb ch2 1/4 db step
 #define MA_thr_lsb_ch2__a 75
 #define MA_thr_lsb_ch2__len 2
 #define MA_thr_lsb_ch2__mask 0x30
 #define MA_thr_lsb_ch2__shift 0x04
 #define MA_thr_lsb_ch2__reset 0x00
-#define set_obj_MA_thr_lsb_ch2(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define set_MA_thr_lsb_ch2(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0xcf)|((y<<4)&0x30)); }) 
-#define get_obj_MA_thr_lsb_ch2(o) (o.read(75) & 0x30)>>4 
-#define get_MA_thr_lsb_ch2() ( ma_read_byte(75) & 0x30)>>4 
+#define set_obj_MA_thr_lsb_ch2(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define set_MA_thr_lsb_ch2(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0xcf) | ((y << 4) & 0x30)); \
+  })
+#define get_obj_MA_thr_lsb_ch2(o) (o.read(75) & 0x30) >> 4
+#define get_MA_thr_lsb_ch2() (ma_read_byte(75) & 0x30) >> 4
 //------------------------------------------------------------------------------thr_lsb_ch3---
-// threshold lsb ch3 
+// threshold lsb ch3
 #define MA_thr_lsb_ch3__a 75
 #define MA_thr_lsb_ch3__len 2
 #define MA_thr_lsb_ch3__mask 0xc0
 #define MA_thr_lsb_ch3__shift 0x06
 #define MA_thr_lsb_ch3__reset 0x00
-#define set_obj_MA_thr_lsb_ch3(o,y) ({ uint8_t __ret = o.read(75); o.write(75,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define set_MA_thr_lsb_ch3(y) ({ uint8_t __ret = ma_read_byte(75); ma_write_byte(75,(__ret&0x3f)|((y<<6)&0xc0)); }) 
-#define get_obj_MA_thr_lsb_ch3(o) (o.read(75) & 0xc0)>>6 
-#define get_MA_thr_lsb_ch3() ( ma_read_byte(75) & 0xc0)>>6 
+#define set_obj_MA_thr_lsb_ch3(o, y)                 \
+  ({                                                 \
+    uint8_t __ret = o.read(75);                      \
+    o.write(75, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define set_MA_thr_lsb_ch3(y)                              \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(75);                      \
+    ma_write_byte(75, (__ret & 0x3f) | ((y << 6) & 0xc0)); \
+  })
+#define get_obj_MA_thr_lsb_ch3(o) (o.read(75) & 0xc0) >> 6
+#define get_MA_thr_lsb_ch3() (ma_read_byte(75) & 0xc0) >> 6
 //------------------------------------------------------------------------------dcu_mon0.PM_mon---
-// Power mode monitor channel 0 
+// Power mode monitor channel 0
 #define MA_dcu_mon0__PM_mon__a 96
 #define MA_dcu_mon0__PM_mon__len 2
 #define MA_dcu_mon0__PM_mon__mask 0x03
 #define MA_dcu_mon0__PM_mon__shift 0x00
 #define MA_dcu_mon0__PM_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__PM_mon(o,y) ({ uint8_t __ret = o.read(96); o.write(96,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_dcu_mon0__PM_mon(y) ({ uint8_t __ret = ma_read_byte(96); ma_write_byte(96,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_dcu_mon0__PM_mon(o) (o.read(96) & 0x03)>>0 
-#define get_MA_dcu_mon0__PM_mon() ( ma_read_byte(96) & 0x03)>>0 
+#define set_obj_MA_dcu_mon0__PM_mon(o, y)            \
+  ({                                                 \
+    uint8_t __ret = o.read(96);                      \
+    o.write(96, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_dcu_mon0__PM_mon(y)                         \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(96);                      \
+    ma_write_byte(96, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_dcu_mon0__PM_mon(o) (o.read(96) & 0x03) >> 0
+#define get_MA_dcu_mon0__PM_mon() (ma_read_byte(96) & 0x03) >> 0
 //------------------------------------------------------------------------------dcu_mon0.freqMode_mon---
-// Frequence mode monitor channel 0 
+// Frequence mode monitor channel 0
 #define MA_dcu_mon0__freqMode_mon__a 96
 #define MA_dcu_mon0__freqMode_mon__len 3
 #define MA_dcu_mon0__freqMode_mon__mask 0x70
 #define MA_dcu_mon0__freqMode_mon__shift 0x04
 #define MA_dcu_mon0__freqMode_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__freqMode_mon(o,y) ({ uint8_t __ret = o.read(96); o.write(96,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define set_MA_dcu_mon0__freqMode_mon(y) ({ uint8_t __ret = ma_read_byte(96); ma_write_byte(96,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define get_obj_MA_dcu_mon0__freqMode_mon(o) (o.read(96) & 0x70)>>4 
-#define get_MA_dcu_mon0__freqMode_mon() ( ma_read_byte(96) & 0x70)>>4 
+#define set_obj_MA_dcu_mon0__freqMode_mon(o, y)      \
+  ({                                                 \
+    uint8_t __ret = o.read(96);                      \
+    o.write(96, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define set_MA_dcu_mon0__freqMode_mon(y)                   \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(96);                      \
+    ma_write_byte(96, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define get_obj_MA_dcu_mon0__freqMode_mon(o) (o.read(96) & 0x70) >> 4
+#define get_MA_dcu_mon0__freqMode_mon() (ma_read_byte(96) & 0x70) >> 4
 //------------------------------------------------------------------------------dcu_mon0.pps_passed---
-// DCU0 PPS completion indicator 
+// DCU0 PPS completion indicator
 #define MA_dcu_mon0__pps_passed__a 96
 #define MA_dcu_mon0__pps_passed__len 1
 #define MA_dcu_mon0__pps_passed__mask 0x80
 #define MA_dcu_mon0__pps_passed__shift 0x07
 #define MA_dcu_mon0__pps_passed__reset 0x00
-#define set_obj_MA_dcu_mon0__pps_passed(o,y) ({ uint8_t __ret = o.read(96); o.write(96,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_dcu_mon0__pps_passed(y) ({ uint8_t __ret = ma_read_byte(96); ma_write_byte(96,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_dcu_mon0__pps_passed(o) (o.read(96) & 0x80)>>7 
-#define get_MA_dcu_mon0__pps_passed() ( ma_read_byte(96) & 0x80)>>7 
+#define set_obj_MA_dcu_mon0__pps_passed(o, y)        \
+  ({                                                 \
+    uint8_t __ret = o.read(96);                      \
+    o.write(96, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_dcu_mon0__pps_passed(y)                     \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(96);                      \
+    ma_write_byte(96, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_dcu_mon0__pps_passed(o) (o.read(96) & 0x80) >> 7
+#define get_MA_dcu_mon0__pps_passed() (ma_read_byte(96) & 0x80) >> 7
 //------------------------------------------------------------------------------dcu_mon0.OCP_mon---
-// OCP Monitor channel 0 
+// OCP Monitor channel 0
 #define MA_dcu_mon0__OCP_mon__a 97
 #define MA_dcu_mon0__OCP_mon__len 1
 #define MA_dcu_mon0__OCP_mon__mask 0x01
 #define MA_dcu_mon0__OCP_mon__shift 0x00
 #define MA_dcu_mon0__OCP_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__OCP_mon(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_dcu_mon0__OCP_mon(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_dcu_mon0__OCP_mon(o) (o.read(97) & 0x01)>>0 
-#define get_MA_dcu_mon0__OCP_mon() ( ma_read_byte(97) & 0x01)>>0 
+#define set_obj_MA_dcu_mon0__OCP_mon(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_dcu_mon0__OCP_mon(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_dcu_mon0__OCP_mon(o) (o.read(97) & 0x01) >> 0
+#define get_MA_dcu_mon0__OCP_mon() (ma_read_byte(97) & 0x01) >> 0
 //------------------------------------------------------------------------------dcu_mon0.Vcfly1_ok---
-// Cfly1 protection monitor channel 0. 
+// Cfly1 protection monitor channel 0.
 #define MA_dcu_mon0__Vcfly1_ok__a 97
 #define MA_dcu_mon0__Vcfly1_ok__len 1
 #define MA_dcu_mon0__Vcfly1_ok__mask 0x02
 #define MA_dcu_mon0__Vcfly1_ok__shift 0x01
 #define MA_dcu_mon0__Vcfly1_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__Vcfly1_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_dcu_mon0__Vcfly1_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_dcu_mon0__Vcfly1_ok(o) (o.read(97) & 0x02)>>1 
-#define get_MA_dcu_mon0__Vcfly1_ok() ( ma_read_byte(97) & 0x02)>>1 
+#define set_obj_MA_dcu_mon0__Vcfly1_ok(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_dcu_mon0__Vcfly1_ok(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_dcu_mon0__Vcfly1_ok(o) (o.read(97) & 0x02) >> 1
+#define get_MA_dcu_mon0__Vcfly1_ok() (ma_read_byte(97) & 0x02) >> 1
 //------------------------------------------------------------------------------dcu_mon0.Vcfly2_ok---
-// Cfly2 protection monitor channel 0. 
+// Cfly2 protection monitor channel 0.
 #define MA_dcu_mon0__Vcfly2_ok__a 97
 #define MA_dcu_mon0__Vcfly2_ok__len 1
 #define MA_dcu_mon0__Vcfly2_ok__mask 0x04
 #define MA_dcu_mon0__Vcfly2_ok__shift 0x02
 #define MA_dcu_mon0__Vcfly2_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__Vcfly2_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_dcu_mon0__Vcfly2_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_dcu_mon0__Vcfly2_ok(o) (o.read(97) & 0x04)>>2 
-#define get_MA_dcu_mon0__Vcfly2_ok() ( ma_read_byte(97) & 0x04)>>2 
+#define set_obj_MA_dcu_mon0__Vcfly2_ok(o, y)         \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_dcu_mon0__Vcfly2_ok(y)                      \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_dcu_mon0__Vcfly2_ok(o) (o.read(97) & 0x04) >> 2
+#define get_MA_dcu_mon0__Vcfly2_ok() (ma_read_byte(97) & 0x04) >> 2
 //------------------------------------------------------------------------------dcu_mon0.pvdd_ok---
-// DCU0 PVDD monitor 
+// DCU0 PVDD monitor
 #define MA_dcu_mon0__pvdd_ok__a 97
 #define MA_dcu_mon0__pvdd_ok__len 1
 #define MA_dcu_mon0__pvdd_ok__mask 0x08
 #define MA_dcu_mon0__pvdd_ok__shift 0x03
 #define MA_dcu_mon0__pvdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__pvdd_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define set_MA_dcu_mon0__pvdd_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define get_obj_MA_dcu_mon0__pvdd_ok(o) (o.read(97) & 0x08)>>3 
-#define get_MA_dcu_mon0__pvdd_ok() ( ma_read_byte(97) & 0x08)>>3 
+#define set_obj_MA_dcu_mon0__pvdd_ok(o, y)           \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define set_MA_dcu_mon0__pvdd_ok(y)                        \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define get_obj_MA_dcu_mon0__pvdd_ok(o) (o.read(97) & 0x08) >> 3
+#define get_MA_dcu_mon0__pvdd_ok() (ma_read_byte(97) & 0x08) >> 3
 //------------------------------------------------------------------------------dcu_mon0.vdd_ok---
-// DCU0 VDD monitor 
+// DCU0 VDD monitor
 #define MA_dcu_mon0__vdd_ok__a 97
 #define MA_dcu_mon0__vdd_ok__len 1
 #define MA_dcu_mon0__vdd_ok__mask 0x10
 #define MA_dcu_mon0__vdd_ok__shift 0x04
 #define MA_dcu_mon0__vdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon0__vdd_ok(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define set_MA_dcu_mon0__vdd_ok(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define get_obj_MA_dcu_mon0__vdd_ok(o) (o.read(97) & 0x10)>>4 
-#define get_MA_dcu_mon0__vdd_ok() ( ma_read_byte(97) & 0x10)>>4 
+#define set_obj_MA_dcu_mon0__vdd_ok(o, y)            \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define set_MA_dcu_mon0__vdd_ok(y)                         \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define get_obj_MA_dcu_mon0__vdd_ok(o) (o.read(97) & 0x10) >> 4
+#define get_MA_dcu_mon0__vdd_ok() (ma_read_byte(97) & 0x10) >> 4
 //------------------------------------------------------------------------------dcu_mon0.mute---
-// DCU0 mute monitor 
+// DCU0 mute monitor
 #define MA_dcu_mon0__mute__a 97
 #define MA_dcu_mon0__mute__len 1
 #define MA_dcu_mon0__mute__mask 0x20
 #define MA_dcu_mon0__mute__shift 0x05
 #define MA_dcu_mon0__mute__reset 0x00
-#define set_obj_MA_dcu_mon0__mute(o,y) ({ uint8_t __ret = o.read(97); o.write(97,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_dcu_mon0__mute(y) ({ uint8_t __ret = ma_read_byte(97); ma_write_byte(97,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_dcu_mon0__mute(o) (o.read(97) & 0x20)>>5 
-#define get_MA_dcu_mon0__mute() ( ma_read_byte(97) & 0x20)>>5 
+#define set_obj_MA_dcu_mon0__mute(o, y)              \
+  ({                                                 \
+    uint8_t __ret = o.read(97);                      \
+    o.write(97, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_dcu_mon0__mute(y)                           \
+  ({                                                       \
+    uint8_t __ret = ma_read_byte(97);                      \
+    ma_write_byte(97, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_dcu_mon0__mute(o) (o.read(97) & 0x20) >> 5
+#define get_MA_dcu_mon0__mute() (ma_read_byte(97) & 0x20) >> 5
 //------------------------------------------------------------------------------dcu_mon0.M_mon---
-// M sense monitor channel 0 
+// M sense monitor channel 0
 #define MA_dcu_mon0__M_mon__a 98
 #define MA_dcu_mon0__M_mon__len 8
 #define MA_dcu_mon0__M_mon__mask 0xff
 #define MA_dcu_mon0__M_mon__shift 0x00
 #define MA_dcu_mon0__M_mon__reset 0x00
-#define set_obj_MA_dcu_mon0__M_mon(o,y) o.write(98,y);
-#define set_MA_dcu_mon0__M_mon(y) ma_write_byte(98,y);
-#define get_obj_MA_dcu_mon0__M_mon(o) (o.read(98) & 0xff)>>0 
-#define get_MA_dcu_mon0__M_mon() ( ma_read_byte(98) & 0xff)>>0 
+#define set_obj_MA_dcu_mon0__M_mon(o, y) o.write(98, y);
+#define set_MA_dcu_mon0__M_mon(y) ma_write_byte(98, y);
+#define get_obj_MA_dcu_mon0__M_mon(o) (o.read(98) & 0xff) >> 0
+#define get_MA_dcu_mon0__M_mon() (ma_read_byte(98) & 0xff) >> 0
 //------------------------------------------------------------------------------dcu_mon1.PM_mon---
-// Power mode monitor channel 1 
+// Power mode monitor channel 1
 #define MA_dcu_mon1__PM_mon__a 100
 #define MA_dcu_mon1__PM_mon__len 2
 #define MA_dcu_mon1__PM_mon__mask 0x03
 #define MA_dcu_mon1__PM_mon__shift 0x00
 #define MA_dcu_mon1__PM_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__PM_mon(o,y) ({ uint8_t __ret = o.read(100); o.write(100,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_dcu_mon1__PM_mon(y) ({ uint8_t __ret = ma_read_byte(100); ma_write_byte(100,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_dcu_mon1__PM_mon(o) (o.read(100) & 0x03)>>0 
-#define get_MA_dcu_mon1__PM_mon() ( ma_read_byte(100) & 0x03)>>0 
+#define set_obj_MA_dcu_mon1__PM_mon(o, y)             \
+  ({                                                  \
+    uint8_t __ret = o.read(100);                      \
+    o.write(100, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_dcu_mon1__PM_mon(y)                          \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(100);                      \
+    ma_write_byte(100, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_dcu_mon1__PM_mon(o) (o.read(100) & 0x03) >> 0
+#define get_MA_dcu_mon1__PM_mon() (ma_read_byte(100) & 0x03) >> 0
 //------------------------------------------------------------------------------dcu_mon1.freqMode_mon---
-// Frequence mode monitor channel 1 
+// Frequence mode monitor channel 1
 #define MA_dcu_mon1__freqMode_mon__a 100
 #define MA_dcu_mon1__freqMode_mon__len 3
 #define MA_dcu_mon1__freqMode_mon__mask 0x70
 #define MA_dcu_mon1__freqMode_mon__shift 0x04
 #define MA_dcu_mon1__freqMode_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__freqMode_mon(o,y) ({ uint8_t __ret = o.read(100); o.write(100,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define set_MA_dcu_mon1__freqMode_mon(y) ({ uint8_t __ret = ma_read_byte(100); ma_write_byte(100,(__ret&0x8f)|((y<<4)&0x70)); }) 
-#define get_obj_MA_dcu_mon1__freqMode_mon(o) (o.read(100) & 0x70)>>4 
-#define get_MA_dcu_mon1__freqMode_mon() ( ma_read_byte(100) & 0x70)>>4 
+#define set_obj_MA_dcu_mon1__freqMode_mon(o, y)       \
+  ({                                                  \
+    uint8_t __ret = o.read(100);                      \
+    o.write(100, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define set_MA_dcu_mon1__freqMode_mon(y)                    \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(100);                      \
+    ma_write_byte(100, (__ret & 0x8f) | ((y << 4) & 0x70)); \
+  })
+#define get_obj_MA_dcu_mon1__freqMode_mon(o) (o.read(100) & 0x70) >> 4
+#define get_MA_dcu_mon1__freqMode_mon() (ma_read_byte(100) & 0x70) >> 4
 //------------------------------------------------------------------------------dcu_mon1.pps_passed---
-// DCU1 PPS completion indicator 
+// DCU1 PPS completion indicator
 #define MA_dcu_mon1__pps_passed__a 100
 #define MA_dcu_mon1__pps_passed__len 1
 #define MA_dcu_mon1__pps_passed__mask 0x80
 #define MA_dcu_mon1__pps_passed__shift 0x07
 #define MA_dcu_mon1__pps_passed__reset 0x00
-#define set_obj_MA_dcu_mon1__pps_passed(o,y) ({ uint8_t __ret = o.read(100); o.write(100,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_dcu_mon1__pps_passed(y) ({ uint8_t __ret = ma_read_byte(100); ma_write_byte(100,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_dcu_mon1__pps_passed(o) (o.read(100) & 0x80)>>7 
-#define get_MA_dcu_mon1__pps_passed() ( ma_read_byte(100) & 0x80)>>7 
+#define set_obj_MA_dcu_mon1__pps_passed(o, y)         \
+  ({                                                  \
+    uint8_t __ret = o.read(100);                      \
+    o.write(100, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_dcu_mon1__pps_passed(y)                      \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(100);                      \
+    ma_write_byte(100, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_dcu_mon1__pps_passed(o) (o.read(100) & 0x80) >> 7
+#define get_MA_dcu_mon1__pps_passed() (ma_read_byte(100) & 0x80) >> 7
 //------------------------------------------------------------------------------dcu_mon1.OCP_mon---
-// OCP Monitor channel 1 
+// OCP Monitor channel 1
 #define MA_dcu_mon1__OCP_mon__a 101
 #define MA_dcu_mon1__OCP_mon__len 1
 #define MA_dcu_mon1__OCP_mon__mask 0x01
 #define MA_dcu_mon1__OCP_mon__shift 0x00
 #define MA_dcu_mon1__OCP_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__OCP_mon(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define set_MA_dcu_mon1__OCP_mon(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xfe)|((y<<0)&0x01)); }) 
-#define get_obj_MA_dcu_mon1__OCP_mon(o) (o.read(101) & 0x01)>>0 
-#define get_MA_dcu_mon1__OCP_mon() ( ma_read_byte(101) & 0x01)>>0 
+#define set_obj_MA_dcu_mon1__OCP_mon(o, y)            \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define set_MA_dcu_mon1__OCP_mon(y)                         \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xfe) | ((y << 0) & 0x01)); \
+  })
+#define get_obj_MA_dcu_mon1__OCP_mon(o) (o.read(101) & 0x01) >> 0
+#define get_MA_dcu_mon1__OCP_mon() (ma_read_byte(101) & 0x01) >> 0
 //------------------------------------------------------------------------------dcu_mon1.Vcfly1_ok---
-// Cfly1 protcetion monitor channel 1 
+// Cfly1 protcetion monitor channel 1
 #define MA_dcu_mon1__Vcfly1_ok__a 101
 #define MA_dcu_mon1__Vcfly1_ok__len 1
 #define MA_dcu_mon1__Vcfly1_ok__mask 0x02
 #define MA_dcu_mon1__Vcfly1_ok__shift 0x01
 #define MA_dcu_mon1__Vcfly1_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__Vcfly1_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define set_MA_dcu_mon1__Vcfly1_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xfd)|((y<<1)&0x02)); }) 
-#define get_obj_MA_dcu_mon1__Vcfly1_ok(o) (o.read(101) & 0x02)>>1 
-#define get_MA_dcu_mon1__Vcfly1_ok() ( ma_read_byte(101) & 0x02)>>1 
+#define set_obj_MA_dcu_mon1__Vcfly1_ok(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define set_MA_dcu_mon1__Vcfly1_ok(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xfd) | ((y << 1) & 0x02)); \
+  })
+#define get_obj_MA_dcu_mon1__Vcfly1_ok(o) (o.read(101) & 0x02) >> 1
+#define get_MA_dcu_mon1__Vcfly1_ok() (ma_read_byte(101) & 0x02) >> 1
 //------------------------------------------------------------------------------dcu_mon1.Vcfly2_ok---
-// Cfly2 protection monitor channel 1 
+// Cfly2 protection monitor channel 1
 #define MA_dcu_mon1__Vcfly2_ok__a 101
 #define MA_dcu_mon1__Vcfly2_ok__len 1
 #define MA_dcu_mon1__Vcfly2_ok__mask 0x04
 #define MA_dcu_mon1__Vcfly2_ok__shift 0x02
 #define MA_dcu_mon1__Vcfly2_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__Vcfly2_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define set_MA_dcu_mon1__Vcfly2_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xfb)|((y<<2)&0x04)); }) 
-#define get_obj_MA_dcu_mon1__Vcfly2_ok(o) (o.read(101) & 0x04)>>2 
-#define get_MA_dcu_mon1__Vcfly2_ok() ( ma_read_byte(101) & 0x04)>>2 
+#define set_obj_MA_dcu_mon1__Vcfly2_ok(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define set_MA_dcu_mon1__Vcfly2_ok(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xfb) | ((y << 2) & 0x04)); \
+  })
+#define get_obj_MA_dcu_mon1__Vcfly2_ok(o) (o.read(101) & 0x04) >> 2
+#define get_MA_dcu_mon1__Vcfly2_ok() (ma_read_byte(101) & 0x04) >> 2
 //------------------------------------------------------------------------------dcu_mon1.pvdd_ok---
-// DCU1 PVDD monitor 
+// DCU1 PVDD monitor
 #define MA_dcu_mon1__pvdd_ok__a 101
 #define MA_dcu_mon1__pvdd_ok__len 1
 #define MA_dcu_mon1__pvdd_ok__mask 0x08
 #define MA_dcu_mon1__pvdd_ok__shift 0x03
 #define MA_dcu_mon1__pvdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__pvdd_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define set_MA_dcu_mon1__pvdd_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xf7)|((y<<3)&0x08)); }) 
-#define get_obj_MA_dcu_mon1__pvdd_ok(o) (o.read(101) & 0x08)>>3 
-#define get_MA_dcu_mon1__pvdd_ok() ( ma_read_byte(101) & 0x08)>>3 
+#define set_obj_MA_dcu_mon1__pvdd_ok(o, y)            \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define set_MA_dcu_mon1__pvdd_ok(y)                         \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xf7) | ((y << 3) & 0x08)); \
+  })
+#define get_obj_MA_dcu_mon1__pvdd_ok(o) (o.read(101) & 0x08) >> 3
+#define get_MA_dcu_mon1__pvdd_ok() (ma_read_byte(101) & 0x08) >> 3
 //------------------------------------------------------------------------------dcu_mon1.vdd_ok---
-// DCU1 VDD monitor 
+// DCU1 VDD monitor
 #define MA_dcu_mon1__vdd_ok__a 101
 #define MA_dcu_mon1__vdd_ok__len 1
 #define MA_dcu_mon1__vdd_ok__mask 0x10
 #define MA_dcu_mon1__vdd_ok__shift 0x04
 #define MA_dcu_mon1__vdd_ok__reset 0x00
-#define set_obj_MA_dcu_mon1__vdd_ok(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define set_MA_dcu_mon1__vdd_ok(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xef)|((y<<4)&0x10)); }) 
-#define get_obj_MA_dcu_mon1__vdd_ok(o) (o.read(101) & 0x10)>>4 
-#define get_MA_dcu_mon1__vdd_ok() ( ma_read_byte(101) & 0x10)>>4 
+#define set_obj_MA_dcu_mon1__vdd_ok(o, y)             \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define set_MA_dcu_mon1__vdd_ok(y)                          \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xef) | ((y << 4) & 0x10)); \
+  })
+#define get_obj_MA_dcu_mon1__vdd_ok(o) (o.read(101) & 0x10) >> 4
+#define get_MA_dcu_mon1__vdd_ok() (ma_read_byte(101) & 0x10) >> 4
 //------------------------------------------------------------------------------dcu_mon1.mute---
-// DCU1 mute monitor 
+// DCU1 mute monitor
 #define MA_dcu_mon1__mute__a 101
 #define MA_dcu_mon1__mute__len 1
 #define MA_dcu_mon1__mute__mask 0x20
 #define MA_dcu_mon1__mute__shift 0x05
 #define MA_dcu_mon1__mute__reset 0x00
-#define set_obj_MA_dcu_mon1__mute(o,y) ({ uint8_t __ret = o.read(101); o.write(101,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define set_MA_dcu_mon1__mute(y) ({ uint8_t __ret = ma_read_byte(101); ma_write_byte(101,(__ret&0xdf)|((y<<5)&0x20)); }) 
-#define get_obj_MA_dcu_mon1__mute(o) (o.read(101) & 0x20)>>5 
-#define get_MA_dcu_mon1__mute() ( ma_read_byte(101) & 0x20)>>5 
+#define set_obj_MA_dcu_mon1__mute(o, y)               \
+  ({                                                  \
+    uint8_t __ret = o.read(101);                      \
+    o.write(101, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define set_MA_dcu_mon1__mute(y)                            \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(101);                      \
+    ma_write_byte(101, (__ret & 0xdf) | ((y << 5) & 0x20)); \
+  })
+#define get_obj_MA_dcu_mon1__mute(o) (o.read(101) & 0x20) >> 5
+#define get_MA_dcu_mon1__mute() (ma_read_byte(101) & 0x20) >> 5
 //------------------------------------------------------------------------------dcu_mon1.M_mon---
-// M sense monitor channel 1 
+// M sense monitor channel 1
 #define MA_dcu_mon1__M_mon__a 102
 #define MA_dcu_mon1__M_mon__len 8
 #define MA_dcu_mon1__M_mon__mask 0xff
 #define MA_dcu_mon1__M_mon__shift 0x00
 #define MA_dcu_mon1__M_mon__reset 0x00
-#define set_obj_MA_dcu_mon1__M_mon(o,y) o.write(102,y);
-#define set_MA_dcu_mon1__M_mon(y) ma_write_byte(102,y);
-#define get_obj_MA_dcu_mon1__M_mon(o) (o.read(102) & 0xff)>>0 
-#define get_MA_dcu_mon1__M_mon() ( ma_read_byte(102) & 0xff)>>0 
+#define set_obj_MA_dcu_mon1__M_mon(o, y) o.write(102, y);
+#define set_MA_dcu_mon1__M_mon(y) ma_write_byte(102, y);
+#define get_obj_MA_dcu_mon1__M_mon(o) (o.read(102) & 0xff) >> 0
+#define get_MA_dcu_mon1__M_mon() (ma_read_byte(102) & 0xff) >> 0
 //------------------------------------------------------------------------------dcu_mon0.sw_enable---
-// DCU0 Switch enable monitor 
+// DCU0 Switch enable monitor
 #define MA_dcu_mon0__sw_enable__a 104
 #define MA_dcu_mon0__sw_enable__len 1
 #define MA_dcu_mon0__sw_enable__mask 0x40
 #define MA_dcu_mon0__sw_enable__shift 0x06
 #define MA_dcu_mon0__sw_enable__reset 0x00
-#define set_obj_MA_dcu_mon0__sw_enable(o,y) ({ uint8_t __ret = o.read(104); o.write(104,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_dcu_mon0__sw_enable(y) ({ uint8_t __ret = ma_read_byte(104); ma_write_byte(104,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_dcu_mon0__sw_enable(o) (o.read(104) & 0x40)>>6 
-#define get_MA_dcu_mon0__sw_enable() ( ma_read_byte(104) & 0x40)>>6 
+#define set_obj_MA_dcu_mon0__sw_enable(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(104);                      \
+    o.write(104, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_dcu_mon0__sw_enable(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(104);                      \
+    ma_write_byte(104, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_dcu_mon0__sw_enable(o) (o.read(104) & 0x40) >> 6
+#define get_MA_dcu_mon0__sw_enable() (ma_read_byte(104) & 0x40) >> 6
 //------------------------------------------------------------------------------dcu_mon1.sw_enable---
-// DCU1 Switch enable monitor 
+// DCU1 Switch enable monitor
 #define MA_dcu_mon1__sw_enable__a 104
 #define MA_dcu_mon1__sw_enable__len 1
 #define MA_dcu_mon1__sw_enable__mask 0x80
 #define MA_dcu_mon1__sw_enable__shift 0x07
 #define MA_dcu_mon1__sw_enable__reset 0x00
-#define set_obj_MA_dcu_mon1__sw_enable(o,y) ({ uint8_t __ret = o.read(104); o.write(104,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_dcu_mon1__sw_enable(y) ({ uint8_t __ret = ma_read_byte(104); ma_write_byte(104,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_dcu_mon1__sw_enable(o) (o.read(104) & 0x80)>>7 
-#define get_MA_dcu_mon1__sw_enable() ( ma_read_byte(104) & 0x80)>>7 
+#define set_obj_MA_dcu_mon1__sw_enable(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(104);                      \
+    o.write(104, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_dcu_mon1__sw_enable(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(104);                      \
+    ma_write_byte(104, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_dcu_mon1__sw_enable(o) (o.read(104) & 0x80) >> 7
+#define get_MA_dcu_mon1__sw_enable() (ma_read_byte(104) & 0x80) >> 7
 //------------------------------------------------------------------------------hvboot0_ok_mon---
-// HVboot0_ok for test/debug 
+// HVboot0_ok for test/debug
 #define MA_hvboot0_ok_mon__a 105
 #define MA_hvboot0_ok_mon__len 1
 #define MA_hvboot0_ok_mon__mask 0x40
 #define MA_hvboot0_ok_mon__shift 0x06
 #define MA_hvboot0_ok_mon__reset 0x00
-#define set_obj_MA_hvboot0_ok_mon(o,y) ({ uint8_t __ret = o.read(105); o.write(105,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define set_MA_hvboot0_ok_mon(y) ({ uint8_t __ret = ma_read_byte(105); ma_write_byte(105,(__ret&0xbf)|((y<<6)&0x40)); }) 
-#define get_obj_MA_hvboot0_ok_mon(o) (o.read(105) & 0x40)>>6 
-#define get_MA_hvboot0_ok_mon() ( ma_read_byte(105) & 0x40)>>6 
+#define set_obj_MA_hvboot0_ok_mon(o, y)               \
+  ({                                                  \
+    uint8_t __ret = o.read(105);                      \
+    o.write(105, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define set_MA_hvboot0_ok_mon(y)                            \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(105);                      \
+    ma_write_byte(105, (__ret & 0xbf) | ((y << 6) & 0x40)); \
+  })
+#define get_obj_MA_hvboot0_ok_mon(o) (o.read(105) & 0x40) >> 6
+#define get_MA_hvboot0_ok_mon() (ma_read_byte(105) & 0x40) >> 6
 //------------------------------------------------------------------------------hvboot1_ok_mon---
-// HVboot1_ok for test/debug 
+// HVboot1_ok for test/debug
 #define MA_hvboot1_ok_mon__a 105
 #define MA_hvboot1_ok_mon__len 1
 #define MA_hvboot1_ok_mon__mask 0x80
 #define MA_hvboot1_ok_mon__shift 0x07
 #define MA_hvboot1_ok_mon__reset 0x00
-#define set_obj_MA_hvboot1_ok_mon(o,y) ({ uint8_t __ret = o.read(105); o.write(105,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define set_MA_hvboot1_ok_mon(y) ({ uint8_t __ret = ma_read_byte(105); ma_write_byte(105,(__ret&0x7f)|((y<<7)&0x80)); }) 
-#define get_obj_MA_hvboot1_ok_mon(o) (o.read(105) & 0x80)>>7 
-#define get_MA_hvboot1_ok_mon() ( ma_read_byte(105) & 0x80)>>7 
+#define set_obj_MA_hvboot1_ok_mon(o, y)               \
+  ({                                                  \
+    uint8_t __ret = o.read(105);                      \
+    o.write(105, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define set_MA_hvboot1_ok_mon(y)                            \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(105);                      \
+    ma_write_byte(105, (__ret & 0x7f) | ((y << 7) & 0x80)); \
+  })
+#define get_obj_MA_hvboot1_ok_mon(o) (o.read(105) & 0x80) >> 7
+#define get_MA_hvboot1_ok_mon() (ma_read_byte(105) & 0x80) >> 7
 //------------------------------------------------------------------------------error_acc---
-// Accumulated errors, at and after triggering 
+// Accumulated errors, at and after triggering
 #define MA_error_acc__a 109
 #define MA_error_acc__len 8
 #define MA_error_acc__mask 0xff
 #define MA_error_acc__shift 0x00
 #define MA_error_acc__reset 0x00
-#define set_obj_MA_error_acc(o,y) o.write(109,y);
-#define set_MA_error_acc(y) ma_write_byte(109,y);
-#define get_obj_MA_error_acc(o) (o.read(109) & 0xff)>>0 
-#define get_MA_error_acc() ( ma_read_byte(109) & 0xff)>>0 
+#define set_obj_MA_error_acc(o, y) o.write(109, y);
+#define set_MA_error_acc(y) ma_write_byte(109, y);
+#define get_obj_MA_error_acc(o) (o.read(109) & 0xff) >> 0
+#define get_MA_error_acc() (ma_read_byte(109) & 0xff) >> 0
 //------------------------------------------------------------------------------i2s_data_rate---
-// Detected i2s data rate: 00/01/10 = x1/x2/x4 
+// Detected i2s data rate: 00/01/10 = x1/x2/x4
 #define MA_i2s_data_rate__a 116
 #define MA_i2s_data_rate__len 2
 #define MA_i2s_data_rate__mask 0x03
 #define MA_i2s_data_rate__shift 0x00
 #define MA_i2s_data_rate__reset 0x00
-#define set_obj_MA_i2s_data_rate(o,y) ({ uint8_t __ret = o.read(116); o.write(116,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define set_MA_i2s_data_rate(y) ({ uint8_t __ret = ma_read_byte(116); ma_write_byte(116,(__ret&0xfc)|((y<<0)&0x03)); }) 
-#define get_obj_MA_i2s_data_rate(o) (o.read(116) & 0x03)>>0 
-#define get_MA_i2s_data_rate() ( ma_read_byte(116) & 0x03)>>0 
+#define set_obj_MA_i2s_data_rate(o, y)                \
+  ({                                                  \
+    uint8_t __ret = o.read(116);                      \
+    o.write(116, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define set_MA_i2s_data_rate(y)                             \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(116);                      \
+    ma_write_byte(116, (__ret & 0xfc) | ((y << 0) & 0x03)); \
+  })
+#define get_obj_MA_i2s_data_rate(o) (o.read(116) & 0x03) >> 0
+#define get_MA_i2s_data_rate() (ma_read_byte(116) & 0x03) >> 0
 //------------------------------------------------------------------------------audio_in_mode_mon---
-// Audio input mode monitor 
+// Audio input mode monitor
 #define MA_audio_in_mode_mon__a 116
 #define MA_audio_in_mode_mon__len 3
 #define MA_audio_in_mode_mon__mask 0x1c
 #define MA_audio_in_mode_mon__shift 0x02
 #define MA_audio_in_mode_mon__reset 0x00
-#define set_obj_MA_audio_in_mode_mon(o,y) ({ uint8_t __ret = o.read(116); o.write(116,(__ret&0xe3)|((y<<2)&0x1c)); }) 
-#define set_MA_audio_in_mode_mon(y) ({ uint8_t __ret = ma_read_byte(116); ma_write_byte(116,(__ret&0xe3)|((y<<2)&0x1c)); }) 
-#define get_obj_MA_audio_in_mode_mon(o) (o.read(116) & 0x1c)>>2 
-#define get_MA_audio_in_mode_mon() ( ma_read_byte(116) & 0x1c)>>2 
+#define set_obj_MA_audio_in_mode_mon(o, y)            \
+  ({                                                  \
+    uint8_t __ret = o.read(116);                      \
+    o.write(116, (__ret & 0xe3) | ((y << 2) & 0x1c)); \
+  })
+#define set_MA_audio_in_mode_mon(y)                         \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(116);                      \
+    ma_write_byte(116, (__ret & 0xe3) | ((y << 2) & 0x1c)); \
+  })
+#define get_obj_MA_audio_in_mode_mon(o) (o.read(116) & 0x1c) >> 2
+#define get_MA_audio_in_mode_mon() (ma_read_byte(116) & 0x1c) >> 2
 //------------------------------------------------------------------------------msel_mon---
-// MSEL[2:0] monitor register 
+// MSEL[2:0] monitor register
 #define MA_msel_mon__a 117
 #define MA_msel_mon__len 3
 #define MA_msel_mon__mask 0x07
 #define MA_msel_mon__shift 0x00
 #define MA_msel_mon__reset 0x00
-#define set_obj_MA_msel_mon(o,y) ({ uint8_t __ret = o.read(117); o.write(117,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define set_MA_msel_mon(y) ({ uint8_t __ret = ma_read_byte(117); ma_write_byte(117,(__ret&0xf8)|((y<<0)&0x07)); }) 
-#define get_obj_MA_msel_mon(o) (o.read(117) & 0x07)>>0 
-#define get_MA_msel_mon() ( ma_read_byte(117) & 0x07)>>0 
+#define set_obj_MA_msel_mon(o, y)                     \
+  ({                                                  \
+    uint8_t __ret = o.read(117);                      \
+    o.write(117, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define set_MA_msel_mon(y)                                  \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(117);                      \
+    ma_write_byte(117, (__ret & 0xf8) | ((y << 0) & 0x07)); \
+  })
+#define get_obj_MA_msel_mon(o) (o.read(117) & 0x07) >> 0
+#define get_MA_msel_mon() (ma_read_byte(117) & 0x07) >> 0
 //------------------------------------------------------------------------------error---
-// Current error flag monitor reg - for app. ctrl. 
+// Current error flag monitor reg - for app. ctrl.
 #define MA_error__a 124
 #define MA_error__len 8
 #define MA_error__mask 0xff
 #define MA_error__shift 0x00
 #define MA_error__reset 0x00
-#define set_obj_MA_error(o,y) o.write(124,y);
-#define set_MA_error(y) ma_write_byte(124,y);
-#define get_obj_MA_error(o) (o.read(124) & 0xff)>>0 
-#define get_MA_error() ( ma_read_byte(124) & 0xff)>>0 
+#define set_obj_MA_error(o, y) o.write(124, y);
+#define set_MA_error(y) ma_write_byte(124, y);
+#define get_obj_MA_error(o) (o.read(124) & 0xff) >> 0
+#define get_MA_error() (ma_read_byte(124) & 0xff) >> 0
 //------------------------------------------------------------------------------audio_proc_limiter_mon---
-// b7-b4: Channel 3-0 limiter active  
+// b7-b4: Channel 3-0 limiter active
 #define MA_audio_proc_limiter_mon__a 126
 #define MA_audio_proc_limiter_mon__len 4
 #define MA_audio_proc_limiter_mon__mask 0xf0
 #define MA_audio_proc_limiter_mon__shift 0x04
 #define MA_audio_proc_limiter_mon__reset 0x00
-#define set_obj_MA_audio_proc_limiter_mon(o,y) ({ uint8_t __ret = o.read(126); o.write(126,(__ret&0x0f)|((y<<4)&0xf0)); }) 
-#define set_MA_audio_proc_limiter_mon(y) ({ uint8_t __ret = ma_read_byte(126); ma_write_byte(126,(__ret&0x0f)|((y<<4)&0xf0)); }) 
-#define get_obj_MA_audio_proc_limiter_mon(o) (o.read(126) & 0xf0)>>4 
-#define get_MA_audio_proc_limiter_mon() ( ma_read_byte(126) & 0xf0)>>4 
+#define set_obj_MA_audio_proc_limiter_mon(o, y)       \
+  ({                                                  \
+    uint8_t __ret = o.read(126);                      \
+    o.write(126, (__ret & 0x0f) | ((y << 4) & 0xf0)); \
+  })
+#define set_MA_audio_proc_limiter_mon(y)                    \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(126);                      \
+    ma_write_byte(126, (__ret & 0x0f) | ((y << 4) & 0xf0)); \
+  })
+#define get_obj_MA_audio_proc_limiter_mon(o) (o.read(126) & 0xf0) >> 4
+#define get_MA_audio_proc_limiter_mon() (ma_read_byte(126) & 0xf0) >> 4
 //------------------------------------------------------------------------------audio_proc_clip_mon---
-// b3-b0: Channel 3-0 clipping monitor 
+// b3-b0: Channel 3-0 clipping monitor
 #define MA_audio_proc_clip_mon__a 126
 #define MA_audio_proc_clip_mon__len 4
 #define MA_audio_proc_clip_mon__mask 0x0f
 #define MA_audio_proc_clip_mon__shift 0x00
 #define MA_audio_proc_clip_mon__reset 0x00
-#define set_obj_MA_audio_proc_clip_mon(o,y) ({ uint8_t __ret = o.read(126); o.write(126,(__ret&0xf0)|((y<<0)&0x0f)); }) 
-#define set_MA_audio_proc_clip_mon(y) ({ uint8_t __ret = ma_read_byte(126); ma_write_byte(126,(__ret&0xf0)|((y<<0)&0x0f)); }) 
-#define get_obj_MA_audio_proc_clip_mon(o) (o.read(126) & 0x0f)>>0 
-#define get_MA_audio_proc_clip_mon() ( ma_read_byte(126) & 0x0f)>>0 
+#define set_obj_MA_audio_proc_clip_mon(o, y)          \
+  ({                                                  \
+    uint8_t __ret = o.read(126);                      \
+    o.write(126, (__ret & 0xf0) | ((y << 0) & 0x0f)); \
+  })
+#define set_MA_audio_proc_clip_mon(y)                       \
+  ({                                                        \
+    uint8_t __ret = ma_read_byte(126);                      \
+    ma_write_byte(126, (__ret & 0xf0) | ((y << 0) & 0x0f)); \
+  })
+#define get_obj_MA_audio_proc_clip_mon(o) (o.read(126) & 0x0f) >> 0
+#define get_MA_audio_proc_clip_mon() (ma_read_byte(126) & 0x0f) >> 0
 
 //------------------------------------------------------------------------------hw_version---
-// Hardware version ID number 
+// Hardware version ID number
 #define MA_hw_version__a 127
 #define MA_hw_version__len 8
 #define MA_hw_version__mask 0xff
 #define MA_hw_version__shift 0x00
 #define MA_hw_version__reset 0x00
-#define set_obj_MA_hw_version(o,y) o.write(127,y);
-#define set_MA_hw_version(y) ma_write_byte(127,y);
-#define get_obj_MA_hw_version(o) (o.read(127) & 0xff)>>0 
-#define get_MA_hw_version() ( ma_read_byte(127) & 0xff)>>0 
+#define set_obj_MA_hw_version(o, y) o.write(127, y);
+#define set_MA_hw_version(y) ma_write_byte(127, y);
+#define get_obj_MA_hw_version(o) (o.read(127) & 0xff) >> 0
+#define get_MA_hw_version() (ma_read_byte(127) & 0xff) >> 0
 
-
-#endif   /* _MA120X0_H_ */
+#endif /* _MA120X0_H_ */

--- a/components/custom_board/pcm51xx/include/pcm51xx.h
+++ b/components/custom_board/pcm51xx/include/pcm51xx.h
@@ -4,22 +4,24 @@
  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
  * Copyright (c) 2021 David Douard <david.douard@sdfa3.org>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
@@ -33,33 +35,33 @@
 extern "C" {
 #endif
 
-#define PCM51XX_REG_00      0x00
-#define PCM51XX_REG_02      0x02
-#define PCM51XX_REG_03      0x03
-#define PCM51XX_REG_24      0x24
-#define PCM51XX_REG_25      0x25
-#define PCM51XX_REG_26      0x26
-#define PCM51XX_REG_27      0x27
-#define PCM51XX_REG_28      0x28
-#define PCM51XX_REG_29      0x29
-#define PCM51XX_REG_2A      0x2a
-#define PCM51XX_REG_2B      0x2b
-#define PCM51XX_REG_35      0x35
-#define PCM51XX_REG_7E      0x7e
-#define PCM51XX_REG_7F      0x7f
+#define PCM51XX_REG_00 0x00
+#define PCM51XX_REG_02 0x02
+#define PCM51XX_REG_03 0x03
+#define PCM51XX_REG_24 0x24
+#define PCM51XX_REG_25 0x25
+#define PCM51XX_REG_26 0x26
+#define PCM51XX_REG_27 0x27
+#define PCM51XX_REG_28 0x28
+#define PCM51XX_REG_29 0x29
+#define PCM51XX_REG_2A 0x2a
+#define PCM51XX_REG_2B 0x2b
+#define PCM51XX_REG_35 0x35
+#define PCM51XX_REG_7E 0x7e
+#define PCM51XX_REG_7F 0x7f
 
-#define PCM51XX_PAGE_00     0x00
-#define PCM51XX_PAGE_2A     0x2a
+#define PCM51XX_PAGE_00 0x00
+#define PCM51XX_PAGE_2A 0x2a
 
-#define PCM51XX_BOOK_00     0x00
-#define PCM51XX_BOOK_8C     0x8c
+#define PCM51XX_BOOK_00 0x00
+#define PCM51XX_BOOK_8C 0x8c
 
-#define  PCM51XX_REG_VOL_L  0X3D
-#define  PCM51XX_REG_VOL_R  0X3E
-#define  PCM51XX_REG_MUTE   0X03
+#define PCM51XX_REG_VOL_L 0X3D
+#define PCM51XX_REG_VOL_R 0X3E
+#define PCM51XX_REG_MUTE 0X03
 
-#define  PCM51XX_DAMP_MODE_BTL      0x0
-#define  PCM51XX_DAMP_MODE_PBTL     0x04
+#define PCM51XX_DAMP_MODE_BTL 0x0
+#define PCM51XX_DAMP_MODE_PBTL 0x04
 
 /**
  * @brief Initialize TAS5805 codec chip
@@ -105,7 +107,8 @@ esp_err_t pcm51xx_get_volume(int *value);
 
 /**
  * @brief Set TAS5805 mute or not
- *        Continuously call should have an interval time determined by pcm51xx_set_mute_fade()
+ *        Continuously call should have an interval time determined by
+ * pcm51xx_set_mute_fade()
  *
  * @param enable enable(1) or disable(0)
  *

--- a/components/custom_board/pcm51xx/include/pcm51xx_reg_cfg.h
+++ b/components/custom_board/pcm51xx/include/pcm51xx_reg_cfg.h
@@ -3,22 +3,24 @@
  *
  * Copyright (c) 2021 David Douard <david.douard@sdfa3.org>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
@@ -30,22 +32,21 @@ extern "C" {
 #endif
 
 typedef struct {
-    uint8_t offset;
-    uint8_t value;
+  uint8_t offset;
+  uint8_t value;
 } pcm51xx_cfg_reg_t;
-
 
 static const pcm51xx_cfg_reg_t pcm51xx_init_seq[] = {
 
-    //EXIT SHUTDOWN STATE
-    { 0x00, 0x00 }, // SELECT PAGE 0
-    { 0x03, 0x00 }, // UNMUTE
-    { 0x2a, 0x11 }, // DAC DATA PATH L->ch1, R->ch2
-    { 0x02, 0x00 }, // DISABLE STBY
-    { 0x0d, 0x10 }, // BCK as SRC for PLL
-    { 0x25, 0x08 }, // IGNORE MISSING MCLK
-    { 0x3d, 0x55 }, // DIGITAL VOLUME L
-    { 0x3e, 0x55 }, // DIGITAL VOLUME R
+    // EXIT SHUTDOWN STATE
+    {0x00, 0x00},  // SELECT PAGE 0
+    {0x03, 0x00},  // UNMUTE
+    {0x2a, 0x11},  // DAC DATA PATH L->ch1, R->ch2
+    {0x02, 0x00},  // DISABLE STBY
+    {0x0d, 0x10},  // BCK as SRC for PLL
+    {0x25, 0x08},  // IGNORE MISSING MCLK
+    {0x3d, 0x55},  // DIGITAL VOLUME L
+    {0x3e, 0x55},  // DIGITAL VOLUME R
 };
 
 #ifdef __cplusplus

--- a/components/custom_board/pcm51xx/pcm51xx.c
+++ b/components/custom_board/pcm51xx/pcm51xx.c
@@ -4,47 +4,52 @@
  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD>
  * Copyright (c) 2021 David Douard <david.douard@sdfa3.org>
  *
- * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in which case,
- * it is free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
+ * Permission is hereby granted for use on all ESPRESSIF SYSTEMS products, in
+ * which case, it is free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  */
 
-#include "i2c_bus.h"
+#include "pcm51xx.h"
+
 #include "board.h"
 #include "esp_log.h"
-#include "pcm51xx.h"
+#include "i2c_bus.h"
 #include "pcm51xx_reg_cfg.h"
 
 static const char *TAG = "PCM51XX";
 
-#define PCM51XX_BASE_ADDR     0x98
-#define PCM51XX_RST_GPIO      get_pa_enable_gpio()
-#define PCM51XX_VOLUME_MAX    255
-#define PCM51XX_VOLUME_MIN    0
+#define PCM51XX_BASE_ADDR 0x98
+#define PCM51XX_RST_GPIO get_pa_enable_gpio()
+#define PCM51XX_VOLUME_MAX 255
+#define PCM51XX_VOLUME_MIN 0
 
 #define PCM51XX_ASSERT(a, format, b, ...) \
-    if ((a) != 0) { \
-        ESP_LOGE(TAG, format, ##__VA_ARGS__); \
-        return b;\
-    }
+  if ((a) != 0) {                         \
+    ESP_LOGE(TAG, format, ##__VA_ARGS__); \
+    return b;                             \
+  }
 
-esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state);
-esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface);
-static i2c_bus_handle_t     i2c_handler;
+esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode,
+                       audio_hal_ctrl_t ctrl_state);
+esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode,
+                               audio_hal_codec_i2s_iface_t *iface);
+static i2c_bus_handle_t i2c_handler;
 static int pcm51xx_addr;
 
 /*
@@ -58,7 +63,7 @@ static i2c_config_t i2c_cfg = {
 };
 
 /*
- * Operate fuction of PA
+ * Operate function
  */
 audio_hal_func_t AUDIO_CODEC_PCM51XX_DEFAULT_HANDLE = {
     .audio_codec_initialize = pcm51xx_init,
@@ -72,149 +77,143 @@ audio_hal_func_t AUDIO_CODEC_PCM51XX_DEFAULT_HANDLE = {
     .handle = NULL,
 };
 
-static esp_err_t pcm51xx_transmit_registers(const pcm51xx_cfg_reg_t *conf_buf, int size)
-{
-    int i = 0;
-    esp_err_t ret = ESP_OK;
-    while (i < size) {
-		ret = i2c_bus_write_bytes(
-			i2c_handler, pcm51xx_addr,
-			(unsigned char *)(&conf_buf[i].offset), 1,
-			(unsigned char *)(&conf_buf[i].value), 1);
-		i++;
-	}
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Fail to load configuration to pcm51xx");
-        return ESP_FAIL;
+static esp_err_t pcm51xx_transmit_registers(const pcm51xx_cfg_reg_t *conf_buf,
+                                            int size) {
+  int i = 0;
+  esp_err_t ret = ESP_OK;
+  while (i < size) {
+    ret = i2c_bus_write_bytes(i2c_handler, pcm51xx_addr,
+                              (unsigned char *)(&conf_buf[i].offset), 1,
+                              (unsigned char *)(&conf_buf[i].value), 1);
+    i++;
+  }
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Fail to load configuration to pcm51xx");
+    return ESP_FAIL;
+  }
+  ESP_LOGI(TAG, "%s:  write %d reg done", __FUNCTION__, i);
+  return ret;
+}
+
+esp_err_t pcm51xx_init(audio_hal_codec_config_t *codec_cfg) {
+  esp_err_t ret = ESP_OK;
+  ESP_LOGI(TAG, "Power ON CODEC with GPIO %d", PCM51XX_RST_GPIO);
+  // probably unnecessary...
+  /*
+gpio_config_t io_conf;
+io_conf.pin_bit_mask = BIT64(PCM51XX_RST_GPIO);
+io_conf.mode = GPIO_MODE_OUTPUT;
+io_conf.intr_type = GPIO_INTR_DISABLE;
+gpio_config(&io_conf);
+gpio_set_level(PCM51XX_RST_GPIO, 0);
+vTaskDelay(20 / portTICK_RATE_MS);
+gpio_set_level(PCM51XX_RST_GPIO, 1);
+vTaskDelay(200 / portTICK_RATE_MS);
+  */
+
+  ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+  i2c_handler = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
+  if (i2c_handler == NULL) {
+    ESP_LOGW(TAG, "failed to create i2c bus handler\n");
+    return ESP_FAIL;
+  }
+
+  uint8_t data[] = {0, 0};
+  for (int i = 0; i < 4; i++) {
+    pcm51xx_addr = PCM51XX_BASE_ADDR + 2 * i;
+    ESP_LOGI(TAG, "Looking for a pcm51xx chip at address 0x%x", pcm51xx_addr);
+    ret = i2c_bus_write_data(i2c_handler, pcm51xx_addr, data, 0);
+    if (ret == ESP_OK) {
+      ESP_LOGI(TAG, "Found a pcm51xx chip at address 0x%x", pcm51xx_addr);
+      break;
     }
-    ESP_LOGI(TAG, "%s:  write %d reg done", __FUNCTION__, i);
-    return ret;
+  }
+
+  PCM51XX_ASSERT(ret, "Fail to detect pcm51xx PA", ESP_FAIL);
+  ret |= pcm51xx_transmit_registers(
+      pcm51xx_init_seq, sizeof(pcm51xx_init_seq) / sizeof(pcm51xx_init_seq[0]));
+
+  PCM51XX_ASSERT(ret, "Fail to iniitialize pcm51xx PA", ESP_FAIL);
+  return ret;
 }
 
-esp_err_t pcm51xx_init(audio_hal_codec_config_t *codec_cfg)
-{
-    esp_err_t ret = ESP_OK;
-    ESP_LOGI(TAG, "Power ON CODEC with GPIO %d", PCM51XX_RST_GPIO);
-	// probably unnecessary...
-	/*
-    gpio_config_t io_conf;
-    io_conf.pin_bit_mask = BIT64(PCM51XX_RST_GPIO);
-    io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.intr_type = GPIO_INTR_DISABLE;
-    gpio_config(&io_conf);
-    gpio_set_level(PCM51XX_RST_GPIO, 0);
-    vTaskDelay(20 / portTICK_RATE_MS);
-    gpio_set_level(PCM51XX_RST_GPIO, 1);
-    vTaskDelay(200 / portTICK_RATE_MS);
-	*/
+esp_err_t pcm51xx_set_volume(int vol) {
+  // vol is given as 1/2dB step with
+  // 255: -inf (mute)
+  // 254: -103dB
+  // 48:  0dB
+  // 0 (max): +24dB
 
-    ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
-    i2c_handler = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
-    if (i2c_handler == NULL) {
-        ESP_LOGW(TAG, "failed to create i2c bus handler\n");
-        return ESP_FAIL;
-    }
+  if (vol < PCM51XX_VOLUME_MIN) {
+    vol = PCM51XX_VOLUME_MIN;
+  }
+  if (vol > PCM51XX_VOLUME_MAX) {
+    vol = PCM51XX_VOLUME_MAX;
+  }
+  uint8_t cmd[2] = {0, 0};
+  esp_err_t ret = ESP_OK;
 
-	uint8_t data[] = {0, 0};
-	for (int i=0; i<4; i++)
-	{
-		pcm51xx_addr = PCM51XX_BASE_ADDR + 2*i;
-		ESP_LOGI(TAG, "Looking for a pcm51xx chip at address 0x%x", pcm51xx_addr);
-		ret = i2c_bus_write_data(i2c_handler, pcm51xx_addr, data, 0);
-		if (ret == ESP_OK) {
-			ESP_LOGI(TAG, "Found a pcm51xx chip at address 0x%x", pcm51xx_addr);
-			break;
-		}
-	}
+  cmd[1] = vol;
 
-    PCM51XX_ASSERT(ret, "Fail to detect pcm51xx PA", ESP_FAIL);
-    ret |= pcm51xx_transmit_registers(pcm51xx_init_seq, sizeof(pcm51xx_init_seq) / sizeof(pcm51xx_init_seq[0]));
-
-    PCM51XX_ASSERT(ret, "Fail to iniitialize pcm51xx PA", ESP_FAIL);
-    return ret;
+  cmd[0] = PCM51XX_REG_VOL_L;
+  ret = i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
+  cmd[0] = PCM51XX_REG_VOL_R;
+  ret |= i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
+  ESP_LOGW(TAG, "Volume set to 0x%x", cmd[1]);
+  return ret;
 }
 
-esp_err_t pcm51xx_set_volume(int vol)
-{
-    // vol is given as 1/2dB step with
-	// 255: -inf (mute)
-    // 254: -103dB
-	// 48:  0dB
-    // 0 (max): +24dB
-
-    if (vol < PCM51XX_VOLUME_MIN) {
-        vol = PCM51XX_VOLUME_MIN;
-    }
-    if (vol > PCM51XX_VOLUME_MAX) {
-        vol = PCM51XX_VOLUME_MAX;
-    }
-    uint8_t cmd[2] = {0, 0};
-    esp_err_t ret = ESP_OK;
-
-    cmd[1] = vol;
-
-    cmd[0] = PCM51XX_REG_VOL_L;
-    ret = i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-    cmd[0] = PCM51XX_REG_VOL_R;
-    ret |= i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-    ESP_LOGW(TAG, "Volume set to 0x%x", cmd[1]);
-    return ret;
+esp_err_t pcm51xx_get_volume(int *value) {
+  /// FIXME: Got the digit volume is not right.
+  uint8_t cmd[2] = {PCM51XX_REG_VOL_L, 0x00};
+  esp_err_t ret =
+      i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
+  PCM51XX_ASSERT(ret, "Fail to get volume", ESP_FAIL);
+  ESP_LOGI(TAG, "Volume is %d", cmd[1]);
+  *value = cmd[1];
+  return ret;
 }
 
-esp_err_t pcm51xx_get_volume(int *value)
-{
-    /// FIXME: Got the digit volume is not right.
-    uint8_t cmd[2] = {PCM51XX_REG_VOL_L, 0x00};
-    esp_err_t ret = i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-    PCM51XX_ASSERT(ret, "Fail to get volume", ESP_FAIL);
-    ESP_LOGI(TAG, "Volume is %d", cmd[1]);
-    *value = cmd[1];
-    return ret;
+esp_err_t pcm51xx_set_mute(bool enable) {
+  esp_err_t ret = ESP_OK;
+  uint8_t cmd[2] = {PCM51XX_REG_MUTE, 0x00};
+  ret |= i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
+
+  if (enable) {
+    cmd[1] |= 0x11;
+  } else {
+    cmd[1] &= (~0x11);
+  }
+  ret |= i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
+
+  PCM51XX_ASSERT(ret, "Fail to set mute", ESP_FAIL);
+  return ret;
 }
 
-esp_err_t pcm51xx_set_mute(bool enable)
-{
-    esp_err_t ret = ESP_OK;
-    uint8_t cmd[2] = {PCM51XX_REG_MUTE, 0x00};
-    ret |= i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
+esp_err_t pcm51xx_get_mute(bool *enabled) {
+  esp_err_t ret = ESP_OK;
+  uint8_t cmd[2] = {PCM51XX_REG_MUTE, 0x00};
+  ret |= i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
 
-    if (enable) {
-        cmd[1] |= 0x11;
-    } else {
-        cmd[1] &= (~0x11);
-    }
-    ret |= i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-
-    PCM51XX_ASSERT(ret, "Fail to set mute", ESP_FAIL);
-    return ret;
+  PCM51XX_ASSERT(ret, "Fail to get mute", ESP_FAIL);
+  *enabled = (bool)(cmd[1] & 0x11);
+  ESP_LOGI(TAG, "Get mute value: %s", *enabled ? "muted" : "unmuted");
+  return ret;
 }
 
-esp_err_t pcm51xx_get_mute(bool *enabled)
-{
-    esp_err_t ret = ESP_OK;
-    uint8_t cmd[2] = {PCM51XX_REG_MUTE, 0x00};
-    ret |= i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-
-    PCM51XX_ASSERT(ret, "Fail to get mute", ESP_FAIL);
-    *enabled = (bool) (cmd[1] & 0x11);
-    ESP_LOGI(TAG, "Get mute value: %s", *enabled ? "muted" : "unmuted");
-    return ret;
+esp_err_t pcm51xx_deinit(void) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t pcm51xx_deinit(void)
-{
-    // TODO
-    return ESP_OK;
+esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode,
+                       audio_hal_ctrl_t ctrl_state) {
+  // TODO
+  return ESP_OK;
 }
 
-esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode, audio_hal_ctrl_t ctrl_state)
-{
-    // TODO
-    return ESP_OK;
-}
-
-esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface)
-{
-    //TODO
-    return ESP_OK;
+esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode,
+                               audio_hal_codec_i2s_iface_t *iface) {
+  // TODO
+  return ESP_OK;
 }

--- a/components/dsp_processor/dsp_processor.c
+++ b/components/dsp_processor/dsp_processor.c
@@ -1,28 +1,27 @@
 
 
 #include <stdint.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "esp_log.h"
 #include <sys/time.h>
 
 #include "driver/i2s.h"
-#include "freertos/ringbuf.h"
-#include "dsps_biquad_gen.h"
 #include "dsps_biquad.h"
+#include "dsps_biquad_gen.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/ringbuf.h"
+#include "freertos/task.h"
 //#include "websocket_if.h"
-#include "dsp_processor.h"
-
-#include "driver/i2s.h"
 #include "driver/dac.h"
+#include "driver/i2s.h"
+#include "dsp_processor.h"
 #include "hal/i2s_hal.h"
 //#include "adc1_i2s_private.h"
 #include "board_pins_config.h"
 
 #ifdef CONFIG_USE_BIQUAD_ASM
-  #define BIQUAD dsps_biquad_f32_ae32
+#define BIQUAD dsps_biquad_f32_ae32
 #else
-  #define BIQUAD dsps_biquad_f32
+#define BIQUAD dsps_biquad_f32
 #endif
 
 uint32_t bits_per_sample = CONFIG_BITS_PER_SAMPLE;
@@ -38,24 +37,24 @@ extern struct timeval tdif;
 extern uint32_t buffer_ms;
 extern uint8_t muteCH[4];
 
-uint dspFlow = dspfBassBoost ; // dspfStereo; // dspfStereo; //dspfBassBoost;  //dspfStereo;
+uint8_t dspFlow =
+    dspfBassBoost;  // dspfStereo; // dspfStereo; //dspfBassBoost; //dspfStereo;
 
 ptype_t bq[8];
 
-void setup_dsp_i2s(uint32_t sample_rate, bool slave_i2s)
-{
+void setup_dsp_i2s(uint32_t sample_rate, bool slave_i2s) {
   i2s_config_t i2s_config0 = {
-    .mode = I2S_MODE_MASTER | I2S_MODE_TX,                                  // Only TX
-    .sample_rate = sample_rate,
-    .bits_per_sample = bits_per_sample,
-    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,                           // 2-channels
-    .communication_format = I2S_COMM_FORMAT_I2S ,
-    .dma_buf_count = 8,
-    .dma_buf_len = 480,
-    .intr_alloc_flags = 1,                                                  //Default interrupt priority
-    .use_apll = true,
-    .fixed_mclk = 0,
-    .tx_desc_auto_clear = true                                              // Auto clear tx descriptor on underflow
+      .mode = I2S_MODE_MASTER | I2S_MODE_TX,  // Only TX
+      .sample_rate = sample_rate,
+      .bits_per_sample = bits_per_sample,
+      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,  // 2-channels
+      .communication_format = I2S_COMM_FORMAT_I2S,
+      .dma_buf_count = 8,
+      .dma_buf_len = 480,
+      .intr_alloc_flags = 1,  // Default interrupt priority
+      .use_apll = true,
+      .fixed_mclk = 0,
+      .tx_desc_auto_clear = true  // Auto clear tx descriptor on underflow
   };
 
   i2s_pin_config_t pin_config0;
@@ -67,31 +66,30 @@ void setup_dsp_i2s(uint32_t sample_rate, bool slave_i2s)
   gpio_set_drive_capability(CONFIG_MASTER_I2S_BCK_PIN, 0);
   gpio_set_drive_capability(CONFIG_MASTER_I2S_LRCK_PIN, 0);
   gpio_set_drive_capability(CONFIG_MASTER_I2S_DATAOUT_PIN, 0);
-  
+
   if (slave_i2s) {
     i2s_config_t i2s_config1 = {
-      .mode = I2S_MODE_SLAVE | I2S_MODE_TX,                                   // Only TX - Slave channel
-      .sample_rate = sample_rate,
-      .bits_per_sample = bits_per_sample,
-      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,                           // 2-channels
-      .communication_format = I2S_COMM_FORMAT_I2S,
-      .dma_buf_count = 8,
-      .dma_buf_len = 480,
-      .use_apll = true,
-      .fixed_mclk = 0,
-      .tx_desc_auto_clear = true                                              // Auto clear tx descriptor on underflow
+        .mode = I2S_MODE_SLAVE | I2S_MODE_TX,  // Only TX - Slave channel
+        .sample_rate = sample_rate,
+        .bits_per_sample = bits_per_sample,
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,  // 2-channels
+        .communication_format = I2S_COMM_FORMAT_I2S,
+        .dma_buf_count = 8,
+        .dma_buf_len = 480,
+        .use_apll = true,
+        .fixed_mclk = 0,
+        .tx_desc_auto_clear = true  // Auto clear tx descriptor on underflow
     };
     i2s_pin_config_t pin_config1;
     get_i2s_pins(I2S_NUM_1, &pin_config1);
-	  i2s_driver_install(I2S_NUM_1, &i2s_config1, 7, &i2s_queue);
+    i2s_driver_install(I2S_NUM_1, &i2s_config1, 7, &i2s_queue);
     i2s_zero_dma_buffer(1);
     i2s_set_pin(1, &pin_config1);
   }
 }
 
-
-static void dsp_i2s_task_handler(void *arg)
-{ struct timeval now , tv1;
+static void dsp_i2s_task_handler(void *arg) {
+  struct timeval now, tv1;
   uint32_t cnt = 0;
   uint8_t *audio = NULL;
   uint8_t *drainPtr = NULL;
@@ -104,8 +102,8 @@ static void dsp_i2s_task_handler(void *arg)
   float sbufout2[1024];
   float sbuftmp0[1024];
 
-  uint8_t dsp_audio[4*1024];
-  uint8_t dsp_audio1[4*1024];
+  uint8_t dsp_audio[4 * 1024];
+  uint8_t dsp_audio1[4 * 1024];
   size_t n_byte_read = 0;
   size_t chunk_size = 0;
   size_t bytes_written = 0;
@@ -113,13 +111,13 @@ static void dsp_i2s_task_handler(void *arg)
   muteCH[1] = 0;
   muteCH[2] = 0;
   muteCH[3] = 0;
-  //uint32_t inBuffer,freeBuffer,wbuf,rbuf ;
+  // uint32_t inBuffer,freeBuffer,wbuf,rbuf ;
 
-  //static int32_t avgcnt = 0;
-  //uint32_t avgcntlen = 64;  // x 960/4*1/fs = 320ms @48000 kHz
-  //uint32_t avgarray[128] = {0};
-  //uint32_t sum;
-  //float avg = 0.0;
+  // static int32_t avgcnt = 0;
+  // uint32_t avgcntlen = 64;  // x 960/4*1/fs = 320ms @48000 kHz
+  // uint32_t avgarray[128] = {0};
+  // uint32_t sum;
+  // float avg = 0.0;
   int32_t age = 0;
   int32_t agesec;
   int32_t ageusec;
@@ -130,456 +128,505 @@ static void dsp_i2s_task_handler(void *arg)
   double dynamic_vol = 1.0;
   for (;;) {
     // 23.12.2020 - JKJ : Buffer protocol major change
-    //   - Audio data prefaced with timestamp and size tag server timesamp (sec/usec (uint32_t)) and number of bytes (uint32_t)
-    //   - DSP processor is now last in line to quanity if data must be passed on to hw i2s interface buffer or delayed based on
+    //   - Audio data prefaced with timestamp and size tag server timesamp
+    //   (sec/usec (uint32_t)) and number of bytes (uint32_t)
+    //   - DSP processor is now last in line to quanity if data must be passed
+    //   on to hw i2s interface buffer or delayed based on
     //     timestamp
-    //   - Timestamp vs now must be use to schedul if pack must be delay, dropped or played
+    //   - Timestamp vs now must be use to schedul if pack must be delay,
+    //   dropped or played
 
     // Old scheem
     // Condition                                     state   Action
     // Buffer is empty - because not being filled    Stopped  Wait
     // Buffer is increasing and below target         Filling  Wait
-    // Buffer above target                           Playing  Consume from buffer
-    // Buffer is below target                        Playing  Short delay
+    // Buffer above target                           Playing  Consume from
+    // buffer Buffer is below target                        Playing  Short delay
 
-    // Snap client process has a realtime que to signal change in sample flow.
-    // If client is muted from server - DSP output render will be signaled and allowed to take action.
+    // Snap client process has a realtime queue to signal change in sample flow.
+    // If client is muted from server - DSP output render will be signaled and
+    // allowed to take action.
 
     cnt++;
 
-    if (xQueueReceive(flow_queue, &flow_que_msg , 0)) {
-      ESP_LOGI("I2S", "FLOW Que message: %d ",flow_que_msg );
+    if (xQueueReceive(flow_queue, &flow_que_msg, 0)) {
+      ESP_LOGI("I2S", "FLOW Queue message: %d ", flow_que_msg);
       if (flow_state != flow_que_msg) {
-        if (flow_que_msg == 2) {  // front end timed out -- network conjection more then 200 msec or source off
-          if (flow_state == 1) {
+        switch (flow_que_msg) {
+          case 2:  // front end timed out -- network congestion more then 200
+                   // msec or source off
+            if (flow_state == 1) {
+              flow_state = 1;
+            } else {
+              flow_state = 2;
+              flow_drain_counter = 20;
+            }
+            break;
+          case 1:  // Server has muted this channel. Turn down the volume over
+                   // next 10 packages
             flow_state = 1;
-          }
-          else
-          { flow_state = 2;
             flow_drain_counter = 20;
+            break;
+          case 0:  // Reset sync counter and
+            flow_state = 0;
+            playback_synced = 0;
+            dynamic_vol = 1.0;
+            break;
+        }
+      }
+
+      timestampSize = (uint8_t *)xRingbufferReceiveUpTo(
+          s_ringbuf_i2s, &n_byte_read, (portTickType)40, 3 * 4);
+      if (timestampSize == NULL) {
+        ESP_LOGI("I2S", "Wait: no data in buffer %d %d", cnt, n_byte_read);
+        continue;
+      }
+
+      if (n_byte_read != 12) {
+        ESP_LOGI("I2S", "error read from ringbuf %d ", n_byte_read);
+        // TODO find a decent stategy to fall back on our feet...
+      }
+
+      uint32_t ts_sec = *(timestampSize + 0) + (*(timestampSize + 1) << 8) +
+                        (*(timestampSize + 2) << 16) +
+                        (*(timestampSize + 3) << 24);
+
+      uint32_t ts_usec = *(timestampSize + 4) + (*(timestampSize + 5) << 8) +
+                         (*(timestampSize + 6) << 16) +
+                         (*(timestampSize + 7) << 24);
+
+      uint32_t ts_size = *(timestampSize + 8) + (*(timestampSize + 9) << 8) +
+                         (*(timestampSize + 10) << 16) +
+                         (*(timestampSize + 11) << 24);
+      // free the item (timestampSize) space in the ringbuffer
+      vRingbufferReturnItem(s_ringbuf_i2s, (void *)timestampSize);
+
+      // what's this for?
+      while (tdif.tv_sec == 0) {
+        vTaskDelay(1);
+      }
+      gettimeofday(&now, NULL);
+
+      timersub(&now, &tdif, &tv1);
+      // ESP_LOGI("log", "diff :% 11ld.%03ld ", tdif.tv_sec ,
+      // tdif.tv_usec/1000); ESP_LOGI("log", "head :% 11ld.%03ld ", tv1.tv_sec ,
+      // tv1.tv_usec/1000); ESP_LOGI("log", "tsamp :% 11d.%03d ", ts_sec ,
+      // ts_usec/1000);
+
+      ageusec = tv1.tv_usec - ts_usec;
+      agesec = tv1.tv_sec - ts_sec;
+      if (ageusec < 0) {
+        ageusec += 1000000;
+        agesec -= 1;
+      }
+      age = agesec * 1000 + ageusec / 1000;
+
+      if (playback_synced == 1) {
+        if (age < buffer_ms) {  // Too slow speedup playback
+          // rtc_clk_apll_enable(1, sdm0, sdm1, sdm2, odir);
+          // rtc_clk_apll_enable(1, 149, 212, 5, 2);
+        }  // ESP_LOGI("i2s", "%d %d", buffer_ms, age );
+        else {
+          // rtc_clk_apll_enable(1, 149, 212, 5, 2);
+        }
+        // ESP_LOGI("i2s", "%d %d %1.2f ", buffer_ms, age, dynamic_vol );
+      } else {
+        while (age < buffer_ms) {
+          vTaskDelay(2);
+          gettimeofday(&now, NULL);
+          timersub(&now, &tdif, &tv1);
+          ageusec = tv1.tv_usec - ts_usec;
+          agesec = tv1.tv_sec - ts_sec;
+          if (ageusec < 0) {
+            ageusec += 1000000;
+            agesec -= 1;
           }
+          age = agesec * 1000 + ageusec / 1000;
+
+          ESP_LOGI("I2S", "%d %d syncing ... ", buffer_ms, age);
         }
-        if (flow_que_msg == 1) {  // Server has muted this channel. Turn down the volume over next 10 packages
-          flow_state = 1 ;
-          flow_drain_counter = 20;
-        }
-        if (flow_que_msg == 0) {  // Reset sync counter and
-          flow_state = 0;
+        ESP_LOGI("I2S", "%d %d SYNCED ", buffer_ms, age);
+
+        playback_synced = 1;
+      }
+
+      audio = (uint8_t *)xRingbufferReceiveUpTo(s_ringbuf_i2s, &chunk_size,
+                                                (portTickType)20, ts_size);
+      if (chunk_size != ts_size) {
+        ESP_LOGI("I2S", "Error readding audio from ring buf %d %d ", chunk_size,
+                 ts_size);
+      }
+      // printf("Read data   : %d \n",chunk_size );
+
+      // vRingbufferGetInfo(s_ringbuf_i2s, &freeBuffer, &rbuf, &wbuf, NULL,
+      // &inBuffer );
+      /*
+      if (avgcnt >= avgcntlen) { avgcnt = 0; }
+      avgarray[avgcnt++] = inBuffer;
+      sum = 0;
+      for (int n = 0; n < avgcntlen ; n++)
+      { sum = sum + avgarray[n];
+      }
+      avg = sum / avgcntlen;
+
+      #ifndef CONFIG_USE_PSRAM
+        buffer_ms = 150;
+      #endif
+
+      if (inBuffer < (buffer_ms*48*4)) {vTaskDelay(1); }
+      */
+      // audio = (uint8_t *)xRingbufferReceiveUpTo(s_ringbuf_i2s,
+      // &chunk_size,(portTickType) 20 ,960);  // 200 ms timeout
+
+      // audio = (uint8_t *)xRingbufferReceive(s_ringbuf_i2s, &chunk_size,
+      // (portTickType)portMAX_DELAY);
+      /*if (chunk_size == 0)
+      { printf("no data in buffer Error\n",inBuffer);
+
+      }
+      */
+      // else if (inBuffer < (buffer_ms*48*4))
+      //{ printf("Buffering ...  buffer : %d\n",inBuffer);
+      //}
+      if ((flow_state >= 1) & (flow_drain_counter > 0)) {
+        flow_drain_counter--;
+        dynamic_vol = 1.0 / (20 - flow_drain_counter);
+        if (flow_drain_counter == 0) {
+          // Drain buffer
+          vRingbufferReturnItem(s_ringbuf_i2s, (void *)audio);
+          xRingbufferPrintInfo(s_ringbuf_i2s);
+
+          uint32_t drainSize;
+          drainPtr = (uint8_t *)xRingbufferReceive(s_ringbuf_i2s, &drainSize,
+                                                   (portTickType)0);
+          ESP_LOGI("I2S", "Drained Ringbuffer (bytes):%d ", drainSize);
+          if (drainPtr != NULL) {
+            vRingbufferReturnItem(s_ringbuf_i2s, (void *)drainPtr);
+          }
+          xRingbufferPrintInfo(s_ringbuf_i2s);
           playback_synced = 0;
           dynamic_vol = 1.0;
+
+          continue;
         }
       }
-    }
 
-    timestampSize = (uint8_t *)xRingbufferReceiveUpTo(s_ringbuf_i2s,  &n_byte_read, (portTickType) 40, 3*4 ) ;
-    if (timestampSize == NULL)  {
-      ESP_LOGI("I2S", "Wait no data in buffer %d %d ",cnt,n_byte_read);
-      continue;
-    }
-    if (n_byte_read != 12 ) {
-      ESP_LOGI("I2S", "error read from ringbuf %d ",n_byte_read);
-    }
-    uint32_t ts_sec =  *(timestampSize+0)      +
-                      (*(timestampSize+1)<<8)  +
-                      (*(timestampSize+2)<<16) +
-                      (*(timestampSize+3)<<24);
-
-    uint32_t ts_usec =  *(timestampSize+4)     +
-                      (*(timestampSize+5)<<8)  +
-                      (*(timestampSize+6)<<16) +
-                      (*(timestampSize+7)<<24) ;
-
-    uint32_t ts_size =  *(timestampSize+8)      +
-                      (*(timestampSize+9)<<8)   +
-                      (*(timestampSize+10)<<16) +
-                      (*(timestampSize+11)<<24) ;
-
-    vRingbufferReturnItem(s_ringbuf_i2s,(void *)timestampSize);
-
-    while (tdif.tv_sec == 0) { vTaskDelay(1); }
-    gettimeofday(&now, NULL);
-
-    timersub(&now,&tdif,&tv1);
-    //ESP_LOGI("log", "diff :% 11ld.%03ld ", tdif.tv_sec ,  tdif.tv_usec/1000);
-    //ESP_LOGI("log", "head :% 11ld.%03ld ", tv1.tv_sec ,  tv1.tv_usec/1000);
-    //ESP_LOGI("log", "tsamp :% 11d.%03d ", ts_sec ,  ts_usec/1000);
-
-
-    ageusec = ( tv1.tv_usec - ts_usec ) ;
-    agesec  = ( tv1.tv_sec- ts_sec );
-    if (ageusec < 0 ) {
-      ageusec += 1000000;
-      agesec -= 1;
-    }
-    age = agesec * 1000  + ageusec / 1000  ;
-
-    if (playback_synced == 1) {
-      if (age < buffer_ms ) {   // Too slow speedup playback
-       //rtc_clk_apll_enable(1, sdm0, sdm1, sdm2, odir);
-       //rtc_clk_apll_enable(1, 149, 212, 5, 2);
-      }  //ESP_LOGI("i2s", "%d %d", buffer_ms, age );
-      else
       {
-        //rtc_clk_apll_enable(1, 149, 212, 5, 2);
-
-      }
-      //ESP_LOGI("i2s", "%d %d %1.2f ", buffer_ms, age, dynamic_vol );
-    } else
-    { while (age < buffer_ms ) {
-        vTaskDelay(2);
-        gettimeofday(&now, NULL);
-        timersub(&now,&tdif,&tv1);
-        ageusec = ( tv1.tv_usec - ts_usec ) ;
-        agesec  = ( tv1.tv_sec- ts_sec );
-        if (ageusec < 0 ) {
-          ageusec += 1000000;
-          agesec -= 1;
-        }
-        age = agesec * 1000  + ageusec / 1000  ;
-
-        ESP_LOGI("I2S", "%d %d syncing ... ", buffer_ms, age);
-      }
-      ESP_LOGI("I2S", "%d %d SYNCED ", buffer_ms, age);
-
-      playback_synced = 1;
-    }
-
-    audio = (uint8_t *)xRingbufferReceiveUpTo(s_ringbuf_i2s, &chunk_size,(portTickType) 20,ts_size);
-    if (chunk_size != ts_size)
-    { ESP_LOGI("I2S","Error readding audio from ring buf %d %d ", chunk_size, ts_size);
-    }
-    //printf("Read data   : %d \n",chunk_size );
-
-    //vRingbufferGetInfo(s_ringbuf_i2s, &freeBuffer, &rbuf, &wbuf, NULL, &inBuffer );
-    /*
-    if (avgcnt >= avgcntlen) { avgcnt = 0; }
-    avgarray[avgcnt++] = inBuffer;
-    sum = 0;
-    for (int n = 0; n < avgcntlen ; n++)
-    { sum = sum + avgarray[n];
-    }
-    avg = sum / avgcntlen;
-
-    #ifndef CONFIG_USE_PSRAM
-      buffer_ms = 150;
-    #endif
-
-    if (inBuffer < (buffer_ms*48*4)) {vTaskDelay(1); }
-    */
-    //audio = (uint8_t *)xRingbufferReceiveUpTo(s_ringbuf_i2s, &chunk_size,(portTickType) 20 ,960);  // 200 ms timeout
-
-    //audio = (uint8_t *)xRingbufferReceive(s_ringbuf_i2s, &chunk_size, (portTickType)portMAX_DELAY);
-    /*if (chunk_size == 0)
-    { printf("no data in buffer Error\n",inBuffer);
-
-    }
-    */
-    //else if (inBuffer < (buffer_ms*48*4))
-    //{ printf("Buffering ...  buffer : %d\n",inBuffer);
-    //}
-    if ( (flow_state >= 1) & (flow_drain_counter > 0) ) {
-      flow_drain_counter--;
-      dynamic_vol = 1.0/(20-flow_drain_counter);
-      if (flow_drain_counter == 0) {
-         // Drain buffer
-         vRingbufferReturnItem(s_ringbuf_i2s,(void *)audio);
-         xRingbufferPrintInfo(s_ringbuf_i2s);
-
-         uint32_t drainSize ;
-         drainPtr = (uint8_t *)xRingbufferReceive(s_ringbuf_i2s, &drainSize, (portTickType) 0);
-         ESP_LOGI("I2S", "Drained Ringbuffer (bytes):%d ",drainSize);
-         if (drainPtr != NULL) {
-           vRingbufferReturnItem(s_ringbuf_i2s,(void *)drainPtr);
-         }
-         xRingbufferPrintInfo(s_ringbuf_i2s);
-         playback_synced = 0;
-         dynamic_vol = 1.0;
-
-         continue;
-      }
-    }
-
-    {   int16_t len = chunk_size/4;
-        if (cnt%100 == 2)
-        { ESP_LOGI("I2S", "Chunk :%d %d ms",chunk_size, age );
-          //xRingbufferPrintInfo(s_ringbuf_i2s);
+        int16_t len = chunk_size / 4;
+        if (cnt % 100 == 2) {
+          ESP_LOGI("I2S", "Chunk :%d %d ms", chunk_size, age);
+          // xRingbufferPrintInfo(s_ringbuf_i2s);
         }
 
-        for (uint16_t i=0;i<len;i++)
-        {
-          sbuffer0[i] = dynamic_vol * 0.5 * ((float) ((int16_t) (audio[i*4+1]<<8) + audio[i*4+0]))/32768;
-          sbuffer1[i] = dynamic_vol * 0.5 * ((float) ((int16_t) (audio[i*4+3]<<8) + audio[i*4+2]))/32768;
-          sbuffer2[i] = ((sbuffer0[i]/2) +  (sbuffer1[i]/2));
+        for (uint16_t i = 0; i < len; i++) {
+          sbuffer0[i] =
+              dynamic_vol * 0.5 *
+              ((float)((int16_t)(audio[i * 4 + 1] << 8) + audio[i * 4 + 0])) /
+              32768;
+          sbuffer1[i] =
+              dynamic_vol * 0.5 *
+              ((float)((int16_t)(audio[i * 4 + 3] << 8) + audio[i * 4 + 2])) /
+              32768;
+          sbuffer2[i] = ((sbuffer0[i] / 2) + (sbuffer1[i] / 2));
         }
         switch (dspFlow) {
-          case dspfStereo :
-            { //if (cnt%120==0)
-              //{ ESP_LOGI("I2S", "In dspf Stero :%d",chunk_size);
-                  //ws_server_send_bin_client(0,(char*)audio, 240);
-                  //printf("%d %d \n",byteWritten, i2s_evt.size );
-              //}
-              for (uint16_t i=0; i<len; i++)
-              { audio[i*4+0] = (muteCH[0] == 1)? 0 : audio[i*4+0];
-                audio[i*4+1] = (muteCH[0] == 1)? 0 : audio[i*4+1];
-                audio[i*4+2] = (muteCH[1] == 1)? 0 : audio[i*4+2];
-                audio[i*4+3] = (muteCH[1] == 1)? 0 : audio[i*4+3];
-              }
-              if (bits_per_sample == 16) {
-                i2s_write(0,(char*)audio,  chunk_size, &bytes_written, portMAX_DELAY);
-              } else
-              { i2s_write_expand(0, (char*)audio, chunk_size,16,32, &bytes_written, portMAX_DELAY);
-              }
+          case dspfStereo: {  // if (cnt%120==0)
+            //{ ESP_LOGI("I2S", "In dspf Stero :%d",chunk_size);
+            // ws_server_send_bin_client(0,(char*)audio, 240);
+            // printf("%d %d \n",byteWritten, i2s_evt.size );
+            //}
+            for (uint16_t i = 0; i < len; i++) {
+              audio[i * 4 + 0] = (muteCH[0] == 1) ? 0 : audio[i * 4 + 0];
+              audio[i * 4 + 1] = (muteCH[0] == 1) ? 0 : audio[i * 4 + 1];
+              audio[i * 4 + 2] = (muteCH[1] == 1) ? 0 : audio[i * 4 + 2];
+              audio[i * 4 + 3] = (muteCH[1] == 1) ? 0 : audio[i * 4 + 3];
             }
-            break;
-          case dspfBassBoost :
-            {  // CH0 low shelf 6dB @ 400Hz
-               BIQUAD(sbuffer0, sbufout0, len , bq[6].coeffs, bq[6].w);
-               BIQUAD(sbuffer1, sbufout1, len , bq[7].coeffs, bq[7].w);
-               int16_t valint[2];
-               for (uint16_t i=0; i<len; i++)
-               { valint[0] = (muteCH[0] == 1) ? (int16_t) 0 : (int16_t) (sbufout0[i]*32768);
-                 valint[1] = (muteCH[1] == 1) ? (int16_t) 0 : (int16_t) (sbufout1[i]*32768);
-                 dsp_audio[i*4+0] = (valint[0] & 0xff);
-                 dsp_audio[i*4+1] = ((valint[0] & 0xff00)>>8);
-                 dsp_audio[i*4+2] = (valint[1] & 0xff);
-                 dsp_audio[i*4+3] = ((valint[1] & 0xff00)>>8);
-               }
-               if (bits_per_sample == 16) {
-                  i2s_write(0,(char*)dsp_audio,  chunk_size, &bytes_written, portMAX_DELAY);
-               } else
-               { i2s_write_expand(0, (char*)dsp_audio, chunk_size,16,32, &bytes_written, portMAX_DELAY);
-               }
-
+            if (bits_per_sample == 16) {
+              i2s_write(0, (char *)audio, chunk_size, &bytes_written,
+                        portMAX_DELAY);
+            } else {
+              i2s_write_expand(0, (char *)audio, chunk_size, 16, 32,
+                               &bytes_written, portMAX_DELAY);
             }
-            break;
-          case dspfBiamp :
-            { if (cnt%120==0)
-              { ESP_LOGI("I2S", "In dspf biamp :%d",chunk_size);
-                  //ws_server_send_bin_client(0,(char*)audio, 240);
-                  //printf("%d %d \n",byteWritten, i2s_evt.size );
-              }
-              // Process audio ch0 LOW PASS FILTER
-              BIQUAD(sbuffer0, sbuftmp0, len, bq[0].coeffs, bq[0].w);
-              BIQUAD(sbuftmp0, sbufout0, len, bq[1].coeffs, bq[1].w);
-
-              // Process audio ch1 HIGH PASS FILTER
-              BIQUAD(sbuffer0, sbuftmp0, len, bq[2].coeffs, bq[2].w);
-              BIQUAD(sbuftmp0, sbufout1, len, bq[3].coeffs, bq[3].w);
-
-              int16_t valint[2];
-              for (uint16_t i=0; i<len; i++)
-              { valint[0] = (muteCH[0] == 1) ? (int16_t) 0 : (int16_t) (sbufout0[i]*32768);
-                valint[1] = (muteCH[1] == 1) ? (int16_t) 0 : (int16_t) (sbufout1[i]*32768);
-                dsp_audio[i*4+0] = (valint[0] & 0xff);
-                dsp_audio[i*4+1] = ((valint[0] & 0xff00)>>8);
-                dsp_audio[i*4+2] = (valint[1] & 0xff);
-                dsp_audio[i*4+3] = ((valint[1] & 0xff00)>>8);
-              }
-              if (bits_per_sample == 16) {
-                i2s_write(0,(char*)dsp_audio,  chunk_size, &bytes_written, portMAX_DELAY);
-              } else
-              { i2s_write_expand(0, (char*)dsp_audio, chunk_size,16,32, &bytes_written, portMAX_DELAY);
-              }
+          } break;
+          case dspfBassBoost: {  // CH0 low shelf 6dB @ 400Hz
+            BIQUAD(sbuffer0, sbufout0, len, bq[6].coeffs, bq[6].w);
+            BIQUAD(sbuffer1, sbufout1, len, bq[7].coeffs, bq[7].w);
+            int16_t valint[2];
+            for (uint16_t i = 0; i < len; i++) {
+              valint[0] = (muteCH[0] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout0[i] * 32768);
+              valint[1] = (muteCH[1] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout1[i] * 32768);
+              dsp_audio[i * 4 + 0] = (valint[0] & 0xff);
+              dsp_audio[i * 4 + 1] = ((valint[0] & 0xff00) >> 8);
+              dsp_audio[i * 4 + 2] = (valint[1] & 0xff);
+              dsp_audio[i * 4 + 3] = ((valint[1] & 0xff00) >> 8);
             }
-            break;
-
-          case dspf2DOT1 :
-            { // Process audio L + R LOW PASS FILTER
-              BIQUAD(sbuffer2, sbuftmp0, len, bq[0].coeffs, bq[0].w);
-              BIQUAD(sbuftmp0, sbufout2, len, bq[1].coeffs, bq[1].w);
-
-              // Process audio L HIGH PASS FILTER
-              BIQUAD(sbuffer0, sbuftmp0, len, bq[2].coeffs, bq[2].w);
-              BIQUAD(sbuftmp0, sbufout0, len, bq[3].coeffs, bq[3].w);
-
-              // Process audio R HIGH PASS FILTER
-              BIQUAD(sbuffer1, sbuftmp0, len, bq[4].coeffs, bq[4].w);
-              BIQUAD(sbuftmp0, sbufout1, len, bq[5].coeffs, bq[5].w);
-
-              int16_t valint[5];
-              for (uint16_t i=0; i<len; i++)
-              { valint[0] = (muteCH[0] == 1) ? (int16_t) 0 : (int16_t) (sbufout0[i]*32768);
-                valint[1] = (muteCH[1] == 1) ? (int16_t) 0 : (int16_t) (sbufout1[i]*32768);
-                valint[2] = (muteCH[2] == 1) ? (int16_t) 0 : (int16_t) (sbufout2[i]*32768);
-                dsp_audio[i*4+0] = (valint[2] & 0xff);
-                dsp_audio[i*4+1] = ((valint[2] & 0xff00)>>8);
-                dsp_audio[i*4+2] = 0;
-                dsp_audio[i*4+3] = 0;
-
-                dsp_audio1[i*4+0] = (valint[0] & 0xff);
-                dsp_audio1[i*4+1] = ((valint[0] & 0xff00)>>8);
-                dsp_audio1[i*4+2] = (valint[1] & 0xff);
-                dsp_audio1[i*4+3] = ((valint[1] & 0xff00)>>8);
-              }
-              i2s_write_expand(0, (char*)dsp_audio, chunk_size,16,32, &bytes_written, portMAX_DELAY);
-              i2s_write_expand(1, (char*)dsp_audio1, chunk_size,16,32, &bytes_written, portMAX_DELAY);
+            if (bits_per_sample == 16) {
+              i2s_write(0, (char *)dsp_audio, chunk_size, &bytes_written,
+                        portMAX_DELAY);
+            } else {
+              i2s_write_expand(0, (char *)dsp_audio, chunk_size, 16, 32,
+                               &bytes_written, portMAX_DELAY);
             }
-            break;
-          case dspfFunkyHonda :
-            { // Process audio L + R LOW PASS FILTER
-              BIQUAD(sbuffer2, sbuftmp0, len, bq[0].coeffs, bq[0].w);
-              BIQUAD(sbuftmp0, sbufout2, len, bq[1].coeffs, bq[1].w);
 
-              // Process audio L HIGH PASS FILTER
-              BIQUAD(sbuffer0, sbuftmp0, len, bq[2].coeffs, bq[2].w);
-              BIQUAD(sbuftmp0, sbufout0, len, bq[3].coeffs, bq[3].w);
-
-              // Process audio R HIGH PASS FILTER
-              BIQUAD(sbuffer1, sbuftmp0, len, bq[4].coeffs, bq[4].w);
-              BIQUAD(sbuftmp0, sbufout1, len, bq[5].coeffs, bq[5].w);
-
-              uint16_t scale = 16384;  //32768
-              int16_t valint[5];
-              for (uint16_t i=0; i<len; i++)
-              { valint[0] = (muteCH[0] == 1) ? (int16_t) 0 : (int16_t) (sbufout0[i]*scale);
-                valint[1] = (muteCH[1] == 1) ? (int16_t) 0 : (int16_t) (sbufout1[i]*scale);
-                valint[2] = (muteCH[2] == 1) ? (int16_t) 0 : (int16_t) (sbufout2[i]*scale);
-                valint[3] =  valint[0] + valint[2];
-                valint[4] =  -valint[2] ;
-                valint[5] =  -valint[1] - valint[2] ;
-                dsp_audio[i*4+0] = (valint[3] & 0xff);
-                dsp_audio[i*4+1] = ((valint[3] & 0xff00)>>8);
-                dsp_audio[i*4+2] = (valint[2] & 0xff);
-                dsp_audio[i*4+3] = ((valint[2] & 0xff00)>>8);
-
-                dsp_audio1[i*4+0] = (valint[4] & 0xff);
-                dsp_audio1[i*4+1] = ((valint[4] & 0xff00)>>8);
-                dsp_audio1[i*4+2] = (valint[5] & 0xff);
-                dsp_audio1[i*4+3] = ((valint[5] & 0xff00)>>8);
-              }
-              i2s_write_expand(0, (char*)dsp_audio, chunk_size,16,32, &bytes_written, portMAX_DELAY);
-              i2s_write_expand(1, (char*)dsp_audio1, chunk_size,16,32, &bytes_written, portMAX_DELAY);
+          } break;
+          case dspfBiamp: {
+            if (cnt % 120 == 0) {
+              ESP_LOGI("I2S", "In dspf biamp :%d", chunk_size);
+              // ws_server_send_bin_client(0,(char*)audio, 240);
+              // printf("%d %d \n",byteWritten, i2s_evt.size );
             }
-            break;
-          default :
+            // Process audio ch0 LOW PASS FILTER
+            BIQUAD(sbuffer0, sbuftmp0, len, bq[0].coeffs, bq[0].w);
+            BIQUAD(sbuftmp0, sbufout0, len, bq[1].coeffs, bq[1].w);
+
+            // Process audio ch1 HIGH PASS FILTER
+            BIQUAD(sbuffer0, sbuftmp0, len, bq[2].coeffs, bq[2].w);
+            BIQUAD(sbuftmp0, sbufout1, len, bq[3].coeffs, bq[3].w);
+
+            int16_t valint[2];
+            for (uint16_t i = 0; i < len; i++) {
+              valint[0] = (muteCH[0] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout0[i] * 32768);
+              valint[1] = (muteCH[1] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout1[i] * 32768);
+              dsp_audio[i * 4 + 0] = (valint[0] & 0xff);
+              dsp_audio[i * 4 + 1] = ((valint[0] & 0xff00) >> 8);
+              dsp_audio[i * 4 + 2] = (valint[1] & 0xff);
+              dsp_audio[i * 4 + 3] = ((valint[1] & 0xff00) >> 8);
+            }
+            if (bits_per_sample == 16) {
+              i2s_write(0, (char *)dsp_audio, chunk_size, &bytes_written,
+                        portMAX_DELAY);
+            } else {
+              i2s_write_expand(0, (char *)dsp_audio, chunk_size, 16, 32,
+                               &bytes_written, portMAX_DELAY);
+            }
+          } break;
+
+          case dspf2DOT1: {  // Process audio L + R LOW PASS FILTER
+            BIQUAD(sbuffer2, sbuftmp0, len, bq[0].coeffs, bq[0].w);
+            BIQUAD(sbuftmp0, sbufout2, len, bq[1].coeffs, bq[1].w);
+
+            // Process audio L HIGH PASS FILTER
+            BIQUAD(sbuffer0, sbuftmp0, len, bq[2].coeffs, bq[2].w);
+            BIQUAD(sbuftmp0, sbufout0, len, bq[3].coeffs, bq[3].w);
+
+            // Process audio R HIGH PASS FILTER
+            BIQUAD(sbuffer1, sbuftmp0, len, bq[4].coeffs, bq[4].w);
+            BIQUAD(sbuftmp0, sbufout1, len, bq[5].coeffs, bq[5].w);
+
+            int16_t valint[5];
+            for (uint16_t i = 0; i < len; i++) {
+              valint[0] = (muteCH[0] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout0[i] * 32768);
+              valint[1] = (muteCH[1] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout1[i] * 32768);
+              valint[2] = (muteCH[2] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout2[i] * 32768);
+              dsp_audio[i * 4 + 0] = (valint[2] & 0xff);
+              dsp_audio[i * 4 + 1] = ((valint[2] & 0xff00) >> 8);
+              dsp_audio[i * 4 + 2] = 0;
+              dsp_audio[i * 4 + 3] = 0;
+
+              dsp_audio1[i * 4 + 0] = (valint[0] & 0xff);
+              dsp_audio1[i * 4 + 1] = ((valint[0] & 0xff00) >> 8);
+              dsp_audio1[i * 4 + 2] = (valint[1] & 0xff);
+              dsp_audio1[i * 4 + 3] = ((valint[1] & 0xff00) >> 8);
+            }
+            i2s_write_expand(0, (char *)dsp_audio, chunk_size, 16, 32,
+                             &bytes_written, portMAX_DELAY);
+            i2s_write_expand(1, (char *)dsp_audio1, chunk_size, 16, 32,
+                             &bytes_written, portMAX_DELAY);
+          } break;
+          case dspfFunkyHonda: {  // Process audio L + R LOW PASS FILTER
+            BIQUAD(sbuffer2, sbuftmp0, len, bq[0].coeffs, bq[0].w);
+            BIQUAD(sbuftmp0, sbufout2, len, bq[1].coeffs, bq[1].w);
+
+            // Process audio L HIGH PASS FILTER
+            BIQUAD(sbuffer0, sbuftmp0, len, bq[2].coeffs, bq[2].w);
+            BIQUAD(sbuftmp0, sbufout0, len, bq[3].coeffs, bq[3].w);
+
+            // Process audio R HIGH PASS FILTER
+            BIQUAD(sbuffer1, sbuftmp0, len, bq[4].coeffs, bq[4].w);
+            BIQUAD(sbuftmp0, sbufout1, len, bq[5].coeffs, bq[5].w);
+
+            uint16_t scale = 16384;  // 32768
+            int16_t valint[5];
+            for (uint16_t i = 0; i < len; i++) {
+              valint[0] = (muteCH[0] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout0[i] * scale);
+              valint[1] = (muteCH[1] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout1[i] * scale);
+              valint[2] = (muteCH[2] == 1) ? (int16_t)0
+                                           : (int16_t)(sbufout2[i] * scale);
+              valint[3] = valint[0] + valint[2];
+              valint[4] = -valint[2];
+              valint[5] = -valint[1] - valint[2];
+              dsp_audio[i * 4 + 0] = (valint[3] & 0xff);
+              dsp_audio[i * 4 + 1] = ((valint[3] & 0xff00) >> 8);
+              dsp_audio[i * 4 + 2] = (valint[2] & 0xff);
+              dsp_audio[i * 4 + 3] = ((valint[2] & 0xff00) >> 8);
+
+              dsp_audio1[i * 4 + 0] = (valint[4] & 0xff);
+              dsp_audio1[i * 4 + 1] = ((valint[4] & 0xff00) >> 8);
+              dsp_audio1[i * 4 + 2] = (valint[5] & 0xff);
+              dsp_audio1[i * 4 + 3] = ((valint[5] & 0xff00) >> 8);
+            }
+            i2s_write_expand(0, (char *)dsp_audio, chunk_size, 16, 32,
+                             &bytes_written, portMAX_DELAY);
+            i2s_write_expand(1, (char *)dsp_audio1, chunk_size, 16, 32,
+                             &bytes_written, portMAX_DELAY);
+          } break;
+          default:
             break;
         }
 
-
-        //if (cnt%100==0)
+        // if (cnt%100==0)
         //{ //ws_server_send_bin_client(0,(char*)audio, 240);
-          //printf("%d %d \n",byteWritten, i2s_evt.size );
+        // printf("%d %d \n",byteWritten, i2s_evt.size );
         //}
 
-        vRingbufferReturnItem(s_ringbuf_i2s,(void *)audio);
+        vRingbufferReturnItem(s_ringbuf_i2s, (void *)audio);
+      }
     }
   }
-}
-// buffer size must hold 400ms-1000ms  // for 2ch16b48000 that is 76800 - 192000 or 75-188 x 1024
+  // buffer size must hold 400ms-1000ms  // for 2ch16b48000 that is 76800 -
+  // 192000 or 75-188 x 1024
 
-#define BUFFER_SIZE  192*(3840+12)
-//3852
+#define BUFFER_SIZE 192 * (3840 + 12)
+  // 3852
 
-void dsp_i2s_task_init(uint32_t sample_rate,bool slave)
-{ setup_dsp_i2s(sample_rate,slave);
-  #ifdef CONFIG_USE_PSRAM
-   printf("Setup ringbuffer using PSRAM \n");
-   StaticRingbuffer_t *buffer_struct =  (StaticRingbuffer_t *)heap_caps_malloc(sizeof(StaticRingbuffer_t), MALLOC_CAP_SPIRAM);
-   printf("Buffer_struct ok\n");
+  void dsp_i2s_task_init(uint32_t sample_rate, bool slave) {
+    setup_dsp_i2s(sample_rate, slave);
+#ifdef CONFIG_USE_PSRAM
+    printf("Setup ringbuffer using PSRAM \n");
+    StaticRingbuffer_t *buffer_struct = (StaticRingbuffer_t *)heap_caps_malloc(
+        sizeof(StaticRingbuffer_t), MALLOC_CAP_SPIRAM);
+    printf("Buffer_struct ok\n");
 
-   uint8_t *buffer_storage = (uint8_t *)heap_caps_malloc(sizeof(uint8_t)*BUFFER_SIZE, MALLOC_CAP_SPIRAM);
-   printf("Buffer_stoarge ok\n");
-   s_ringbuf_i2s = xRingbufferCreateStatic(BUFFER_SIZE, RINGBUF_TYPE_BYTEBUF, buffer_storage, buffer_struct);
-   printf("Ringbuf ok\n");
-  #else
-   printf("Setup ringbuffer using internal ram - only space for 150ms - Snapcast buffer_ms parameter ignored \n");
-   s_ringbuf_i2s = xRingbufferCreate(32*1024,RINGBUF_TYPE_BYTEBUF);
-  #endif
-  if (s_ringbuf_i2s == NULL) { printf("nospace for ringbuffer\n"); return; }
-  printf("Ringbuffer ok\n");
-  xTaskCreatePinnedToCore(dsp_i2s_task_handler, "DSP_I2S", 48*1024, NULL, 5, &s_dsp_i2s_task_handle,0);
-  //xTaskCreate(dsp_i2s_task_handler, "DSP_I2S", 48*1024, NULL, 7, &s_dsp_i2s_task_handle);
-}
-
-void dsp_i2s_task_deinit(void)
-{ if (s_dsp_i2s_task_handle) {
-    vTaskDelete(s_dsp_i2s_task_handle);
-    s_dsp_i2s_task_handle = NULL;
+    uint8_t *buffer_storage = (uint8_t *)heap_caps_malloc(
+        sizeof(uint8_t) * BUFFER_SIZE, MALLOC_CAP_SPIRAM);
+    printf("Buffer_stoarge ok\n");
+    s_ringbuf_i2s = xRingbufferCreateStatic(BUFFER_SIZE, RINGBUF_TYPE_BYTEBUF,
+                                            buffer_storage, buffer_struct);
+    printf("Ringbuf ok\n");
+#else
+    printf(
+        "Setup ringbuffer using internal ram - only space for 150ms - Snapcast "
+        "buffer_ms parameter ignored \n");
+    s_ringbuf_i2s = xRingbufferCreate(32 * 1024, RINGBUF_TYPE_BYTEBUF);
+#endif
+    if (s_ringbuf_i2s == NULL) {
+      printf("nospace for ringbuffer\n");
+      return;
+    }
+    printf("Ringbuffer ok\n");
+    xTaskCreatePinnedToCore(dsp_i2s_task_handler, "DSP_I2S", 48 * 1024, NULL, 5,
+                            &s_dsp_i2s_task_handle, 0);
+    // xTaskCreate(dsp_i2s_task_handler, "DSP_I2S", 48*1024, NULL, 7,
+    // &s_dsp_i2s_task_handle);
   }
-  if (s_ringbuf_i2s) {
+
+  void dsp_i2s_task_deinit(void) {
+    if (s_dsp_i2s_task_handle) {
+      vTaskDelete(s_dsp_i2s_task_handle);
+      s_dsp_i2s_task_handle = NULL;
+    }
+    if (s_ringbuf_i2s) {
       vRingbufferDelete(s_ringbuf_i2s);
       s_ringbuf_i2s = NULL;
-  }
-}
-
-size_t write_ringbuf(const uint8_t *data, size_t size)
-{
-   BaseType_t done = xRingbufferSend(s_ringbuf_i2s, (void *)data, size, (portTickType)portMAX_DELAY);
-   return (done)?size:0;
-}
-
-
-// ESP32 DSP processor
-//======================================================
-// Each time a buffer of audio is passed to the DSP - samples are
-// processed according to a dynamic list of audio processing nodes.
-
-// Each audio processor node consist of a data struct holding the
-// required weights and states for processing an automomous processing
-// function. The high level parameters is maintained in the structre
-// as well
-
-// Release - Prove off concept
-// ----------------------------------------
-// Fixed 2x2 biquad flow Xover for biAmp systems
-// Interface for cross over frequency and level
-
-void dsp_setup_flow(double freq, uint32_t samplerate) {
-  float f = freq/samplerate/2.0;
-
-  bq[0] = (ptype_t) { LPF, f, 0, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[1] = (ptype_t) { LPF, f, 0, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[2] = (ptype_t) { HPF, f, 0, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[3] = (ptype_t) { HPF, f, 0, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[4] = (ptype_t) { HPF, f, 0, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[5] = (ptype_t) { HPF, f, 0, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[6] = (ptype_t) { LOWSHELF, f, 6, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-  bq[7] = (ptype_t) { LOWSHELF, f, 6, 0.707, NULL, NULL, {0,0,0,0,0}, {0, 0} } ;
-
-  pnode_t * aflow = NULL;
-  aflow = malloc(sizeof(pnode_t));
-  if (aflow == NULL)
-  { printf("Could not create node");
-  }
-
-  for (uint8_t n=0; n<=7; n++)
-  { switch (bq[n].filtertype) {
-      case LOWSHELF: dsps_biquad_gen_lowShelf_f32( bq[n].coeffs, bq[n].freq,bq[n].gain, bq[n].q );
-                break;
-      case LPF: dsps_biquad_gen_lpf_f32( bq[n].coeffs, bq[n].freq, bq[n].q );
-                break;
-      case HPF: dsps_biquad_gen_hpf_f32( bq[n].coeffs, bq[n].freq, bq[n].q );
-                break;
-      default : break;
-    }
-    for (uint8_t i = 0;i <=4 ;i++ )
-    {  printf("%.6f ",bq[n].coeffs[i]);
-    }
-    printf("\n");
- }
-}
-
-
-void dsp_set_xoverfreq(uint8_t freqh, uint8_t freql,uint32_t samplerate) {
-  float freq =  freqh*256 + freql;
-  printf("%f\n",freq);
-  float f = freq/samplerate/2.;
-  for ( int8_t n=0; n<=5; n++)
-  { bq[n].freq = f ;
-    switch (bq[n].filtertype) {
-      case LPF:
-         for (uint8_t i = 0;i <=4 ;i++ )
-         {  printf("%.6f ",bq[n].coeffs[i]);  }
-         printf("\n");
-         dsps_biquad_gen_lpf_f32( bq[n].coeffs, bq[n].freq, bq[n].q );
-         for (uint8_t i = 0;i <=4 ;i++ )
-         {  printf("%.6f ",bq[n].coeffs[i]);  }
-         printf("%f \n",bq[n].freq);
-         break;
-      case HPF:
-         dsps_biquad_gen_hpf_f32( bq[n].coeffs, bq[n].freq, bq[n].q );
-         break;
-      default : break;
     }
   }
-}
+
+  size_t write_ringbuf(const uint8_t *data, size_t size) {
+    BaseType_t done = xRingbufferSend(s_ringbuf_i2s, (void *)data, size,
+                                      (portTickType)portMAX_DELAY);
+    return (done) ? size : 0;
+  }
+
+  // ESP32 DSP processor
+  //======================================================
+  // Each time a buffer of audio is passed to the DSP - samples are
+  // processed according to a dynamic list of audio processing nodes.
+
+  // Each audio processor node consist of a data struct holding the
+  // required weights and states for processing an automomous processing
+  // function. The high level parameters is maintained in the structure
+  // as well
+
+  // Release - Prove off concept
+  // ----------------------------------------
+  // Fixed 2x2 biquad flow Xover for biAmp systems
+  // Interface for cross over frequency and level
+
+  void dsp_setup_flow(double freq, uint32_t samplerate) {
+    float f = freq / samplerate / 2.0;
+
+    bq[0] = (ptype_t){LPF, f, 0, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[1] = (ptype_t){LPF, f, 0, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[2] = (ptype_t){HPF, f, 0, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[3] = (ptype_t){HPF, f, 0, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[4] = (ptype_t){HPF, f, 0, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[5] = (ptype_t){HPF, f, 0, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[6] =
+        (ptype_t){LOWSHELF, f, 6, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+    bq[7] =
+        (ptype_t){LOWSHELF, f, 6, 0.707, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0}};
+
+    pnode_t *aflow = NULL;
+    aflow = malloc(sizeof(pnode_t));
+    if (aflow == NULL) {
+      printf("Could not create node");
+    }
+
+    for (uint8_t n = 0; n <= 7; n++) {
+      switch (bq[n].filtertype) {
+        case LOWSHELF:
+          dsps_biquad_gen_lowShelf_f32(bq[n].coeffs, bq[n].freq, bq[n].gain,
+                                       bq[n].q);
+          break;
+        case LPF:
+          dsps_biquad_gen_lpf_f32(bq[n].coeffs, bq[n].freq, bq[n].q);
+          break;
+        case HPF:
+          dsps_biquad_gen_hpf_f32(bq[n].coeffs, bq[n].freq, bq[n].q);
+          break;
+        default:
+          break;
+      }
+      for (uint8_t i = 0; i <= 4; i++) {
+        printf("%.6f ", bq[n].coeffs[i]);
+      }
+      printf("\n");
+    }
+  }
+
+  void dsp_set_xoverfreq(uint8_t freqh, uint8_t freql, uint32_t samplerate) {
+    float freq = freqh * 256 + freql;
+    printf("%f\n", freq);
+    float f = freq / samplerate / 2.;
+    for (int8_t n = 0; n <= 5; n++) {
+      bq[n].freq = f;
+      switch (bq[n].filtertype) {
+        case LPF:
+          for (uint8_t i = 0; i <= 4; i++) {
+            printf("%.6f ", bq[n].coeffs[i]);
+          }
+          printf("\n");
+          dsps_biquad_gen_lpf_f32(bq[n].coeffs, bq[n].freq, bq[n].q);
+          for (uint8_t i = 0; i <= 4; i++) {
+            printf("%.6f ", bq[n].coeffs[i]);
+          }
+          printf("%f \n", bq[n].freq);
+          break;
+        case HPF:
+          dsps_biquad_gen_hpf_f32(bq[n].coeffs, bq[n].freq, bq[n].q);
+          break;
+        default:
+          break;
+      }
+    }
+  }

--- a/components/dsp_processor/include/dsp_processor.h
+++ b/components/dsp_processor/include/dsp_processor.h
@@ -1,17 +1,32 @@
 #ifndef _DSP_PROCESSOR_H_
 #define _DSP_PROCESSOR_H_
 
-enum dspFlows {dspfStereo, dspfBiamp, dspf2DOT1, dspfFunkyHonda, dspfBassBoost};
+enum dspFlows {
+  dspfStereo,
+  dspfBiamp,
+  dspf2DOT1,
+  dspfFunkyHonda,
+  dspfBassBoost
+};
 
 size_t write_ringbuf(const uint8_t *data, size_t size);
 
-void dsp_i2s_task_init(uint32_t sample_rate,bool slave);
+void dsp_i2s_task_init(uint32_t sample_rate, bool slave);
 
 void dsp_i2s_task_deinit(void);
 
-enum filtertypes { LPF, HPF, BPF, BPF0DB, NOTCH,
-                   ALLPASS360, ALLPASS180, PEAKINGEQ,
-                   LOWSHELF, HIGHSHELF};
+enum filtertypes {
+  LPF,
+  HPF,
+  BPF,
+  BPF0DB,
+  NOTCH,
+  ALLPASS360,
+  ALLPASS180,
+  PEAKINGEQ,
+  LOWSHELF,
+  HIGHSHELF
+};
 
 // Process node
 typedef struct ptype {
@@ -19,18 +34,18 @@ typedef struct ptype {
   float freq;
   float gain;
   float q;
-  float *in,*out;
+  float *in, *out;
   float coeffs[5];
   float w[2];
 } ptype_t;
 
 // Process flow
 typedef struct pnode {
-    ptype_t process;
-    struct pnode *next;
+  ptype_t process;
+  struct pnode *next;
 } pnode_t;
 
-void dsp_setup_flow(double freq,uint32_t samplerate);
-void dsp_set_xoverfreq(uint8_t, uint8_t, uint32_t );
+void dsp_setup_flow(double freq, uint32_t samplerate);
+void dsp_set_xoverfreq(uint8_t, uint8_t, uint32_t);
 
 #endif /* _DSP_PROCESSOR_H_  */

--- a/components/libbuffer/CMakeLists.txt
+++ b/components/libbuffer/CMakeLists.txt
@@ -1,3 +1,2 @@
 idf_component_register(SRCS "buffer.c"
-                       INCLUDE_DIRS "include") 
-					   
+                       INCLUDE_DIRS "include")

--- a/components/libbuffer/buffer.c
+++ b/components/libbuffer/buffer.c
@@ -1,165 +1,165 @@
 #include "buffer.h"
 
 void buffer_read_init(read_buffer_t *buffer, const char *data, size_t size) {
-    buffer->buffer = data;
-    buffer->size = size;
-    buffer->index = 0;
+  buffer->buffer = data;
+  buffer->size = size;
+  buffer->index = 0;
 }
 
 void buffer_write_init(write_buffer_t *buffer, char *data, size_t size) {
-    buffer->buffer = data;
-    buffer->size = size;
-    buffer->index = 0;
+  buffer->buffer = data;
+  buffer->size = size;
+  buffer->index = 0;
 }
 
 int buffer_read_buffer(read_buffer_t *buffer, char *data, size_t size) {
-    int i;
+  int i;
 
-    if (buffer->size - buffer->index < size) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < size) {
+    return 1;
+  }
 
-    for (i = 0; i < size; i++) {
-        data[i] = buffer->buffer[buffer->index++];
-    }
+  for (i = 0; i < size; i++) {
+    data[i] = buffer->buffer[buffer->index++];
+  }
 
-    return 0;
+  return 0;
 }
 
 int buffer_write_buffer(write_buffer_t *buffer, const char *data, size_t size) {
-    int i;
+  int i;
 
-    if (buffer->size - buffer->index < size) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < size) {
+    return 1;
+  }
 
-    for (i = 0; i < size; i++) {
-        buffer->buffer[buffer->index++] = data[i];
-    }
+  for (i = 0; i < size; i++) {
+    buffer->buffer[buffer->index++] = data[i];
+  }
 
-    return 0;
+  return 0;
 }
 
 int buffer_read_uint32(read_buffer_t *buffer, uint32_t *data) {
-    if (buffer->size - buffer->index < sizeof(uint32_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(uint32_t)) {
+    return 1;
+  }
 
-    *data = buffer->buffer[buffer->index++] & 0xff;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 16;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 24;
-    return 0;
+  *data = buffer->buffer[buffer->index++] & 0xff;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 16;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 24;
+  return 0;
 }
 
 int buffer_write_uint32(write_buffer_t *buffer, uint32_t data) {
-    if (buffer->size - buffer->index < sizeof(uint32_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(uint32_t)) {
+    return 1;
+  }
 
-    buffer->buffer[buffer->index++] = data & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 16) & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 24) & 0xff;
-    return 0;
+  buffer->buffer[buffer->index++] = data & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 16) & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 24) & 0xff;
+  return 0;
 }
 
 int buffer_read_uint16(read_buffer_t *buffer, uint16_t *data) {
-    if (buffer->size - buffer->index < sizeof(uint16_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(uint16_t)) {
+    return 1;
+  }
 
-    *data = buffer->buffer[buffer->index++] & 0xff;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
-    return 0;
+  *data = buffer->buffer[buffer->index++] & 0xff;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
+  return 0;
 }
 
 int buffer_write_uint16(write_buffer_t *buffer, uint16_t data) {
-    if (buffer->size - buffer->index < sizeof(uint16_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(uint16_t)) {
+    return 1;
+  }
 
-    buffer->buffer[buffer->index++] = data & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
-    return 0;
+  buffer->buffer[buffer->index++] = data & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
+  return 0;
 }
 
 int buffer_read_uint8(read_buffer_t *buffer, uint8_t *data) {
-    if (buffer->size - buffer->index < sizeof(uint8_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(uint8_t)) {
+    return 1;
+  }
 
-    *data = buffer->buffer[buffer->index++] & 0xff;
-    return 0;
+  *data = buffer->buffer[buffer->index++] & 0xff;
+  return 0;
 }
 
 int buffer_write_uint8(write_buffer_t *buffer, uint8_t data) {
-    if (buffer->size - buffer->index < sizeof(uint8_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(uint8_t)) {
+    return 1;
+  }
 
-    buffer->buffer[buffer->index++] = data & 0xff;
-    return 0;
+  buffer->buffer[buffer->index++] = data & 0xff;
+  return 0;
 }
 
 int buffer_read_int32(read_buffer_t *buffer, int32_t *data) {
-    if (buffer->size - buffer->index < sizeof(int32_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(int32_t)) {
+    return 1;
+  }
 
-    *data = buffer->buffer[buffer->index++] & 0xff;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 16;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 24;
-    return 0;
+  *data = buffer->buffer[buffer->index++] & 0xff;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 16;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 24;
+  return 0;
 }
 
 int buffer_write_int32(write_buffer_t *buffer, int32_t data) {
-    if (buffer->size - buffer->index < sizeof(int32_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(int32_t)) {
+    return 1;
+  }
 
-    buffer->buffer[buffer->index++] = data & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 16) & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 24) & 0xff;
-    return 0;
+  buffer->buffer[buffer->index++] = data & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 16) & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 24) & 0xff;
+  return 0;
 }
 
 int buffer_read_int16(read_buffer_t *buffer, int16_t *data) {
-    if (buffer->size - buffer->index < sizeof(int16_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(int16_t)) {
+    return 1;
+  }
 
-    *data = buffer->buffer[buffer->index++] & 0xff;
-    *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
-    return 0;
+  *data = buffer->buffer[buffer->index++] & 0xff;
+  *data |= (buffer->buffer[buffer->index++] & 0xff) << 8;
+  return 0;
 }
 
 int buffer_write_int16(write_buffer_t *buffer, int16_t data) {
-    if (buffer->size - buffer->index < sizeof(int16_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(int16_t)) {
+    return 1;
+  }
 
-    buffer->buffer[buffer->index++] = data & 0xff;
-    buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
-    return 0;
+  buffer->buffer[buffer->index++] = data & 0xff;
+  buffer->buffer[buffer->index++] = (data >> 8) & 0xff;
+  return 0;
 }
 
 int buffer_read_int8(read_buffer_t *buffer, int8_t *data) {
-    if (buffer->size - buffer->index < sizeof(int8_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(int8_t)) {
+    return 1;
+  }
 
-    *data = buffer->buffer[buffer->index++] & 0xff;
-    return 0;
+  *data = buffer->buffer[buffer->index++] & 0xff;
+  return 0;
 }
 
 int buffer_write_int8(write_buffer_t *buffer, int8_t data) {
-    if (buffer->size - buffer->index < sizeof(int8_t)) {
-        return 1;
-    }
+  if (buffer->size - buffer->index < sizeof(int8_t)) {
+    return 1;
+  }
 
-    buffer->buffer[buffer->index++] = data & 0xff;
-    return 0;
+  buffer->buffer[buffer->index++] = data & 0xff;
+  return 0;
 }

--- a/components/libbuffer/include/buffer.h
+++ b/components/libbuffer/include/buffer.h
@@ -1,17 +1,17 @@
 #ifndef __BUFFER_H__
 #define __BUFFER_H__
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct read_buffer_t {
-    const char *buffer;
-    size_t size, index;
+  const char *buffer;
+  size_t size, index;
 } read_buffer_t;
 
 typedef struct write_buffer_t {
-    char *buffer;
-    size_t size, index;
+  char *buffer;
+  size_t size, index;
 } write_buffer_t;
 
 /**
@@ -43,7 +43,7 @@ void buffer_write_init(write_buffer_t *buffer, char *data, size_t size);
  * @param[out] data The read data.
  * @param[in] size The size of the array of bytes.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_buffer(read_buffer_t *buffer, char *data, size_t size);
 
 /**
@@ -52,8 +52,9 @@ int buffer_read_buffer(read_buffer_t *buffer, char *data, size_t size);
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
  * @param[in] size The size of the array of bytes.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_buffer(write_buffer_t *buffer, const char *data, size_t size);
 
 /**
@@ -62,7 +63,7 @@ int buffer_write_buffer(write_buffer_t *buffer, const char *data, size_t size);
  * @param[in] buffer The buffer to read from.
  * @param[out] data The read data.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_uint32(read_buffer_t *buffer, uint32_t *data);
 
 /**
@@ -70,8 +71,9 @@ int buffer_read_uint32(read_buffer_t *buffer, uint32_t *data);
  *
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_uint32(write_buffer_t *buffer, uint32_t data);
 
 /**
@@ -80,7 +82,7 @@ int buffer_write_uint32(write_buffer_t *buffer, uint32_t data);
  * @param[in] buffer The buffer to read from.
  * @param[out] data The read data.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_uint16(read_buffer_t *buffer, uint16_t *data);
 
 /**
@@ -88,8 +90,9 @@ int buffer_read_uint16(read_buffer_t *buffer, uint16_t *data);
  *
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_uint16(write_buffer_t *buffer, uint16_t data);
 
 /**
@@ -98,7 +101,7 @@ int buffer_write_uint16(write_buffer_t *buffer, uint16_t data);
  * @param[in] buffer The buffer to read from.
  * @param[out] data The read data.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_uint8(read_buffer_t *buffer, uint8_t *data);
 
 /**
@@ -106,8 +109,9 @@ int buffer_read_uint8(read_buffer_t *buffer, uint8_t *data);
  *
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_uint8(write_buffer_t *buffer, uint8_t data);
 
 /**
@@ -116,7 +120,7 @@ int buffer_write_uint8(write_buffer_t *buffer, uint8_t data);
  * @param[in] buffer The buffer to read from.
  * @param[out] data The read data.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_int32(read_buffer_t *buffer, int32_t *data);
 
 /**
@@ -124,8 +128,9 @@ int buffer_read_int32(read_buffer_t *buffer, int32_t *data);
  *
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_int32(write_buffer_t *buffer, int32_t data);
 
 /**
@@ -134,7 +139,7 @@ int buffer_write_int32(write_buffer_t *buffer, int32_t data);
  * @param[in] buffer The buffer to read from.
  * @param[out] data The read data.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_int16(read_buffer_t *buffer, int16_t *data);
 
 /**
@@ -142,8 +147,9 @@ int buffer_read_int16(read_buffer_t *buffer, int16_t *data);
  *
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_int16(write_buffer_t *buffer, int16_t data);
 
 /**
@@ -152,7 +158,7 @@ int buffer_write_int16(write_buffer_t *buffer, int16_t data);
  * @param[in] buffer The buffer to read from.
  * @param[out] data The read data.
  * @return 1 if there are not enough bytes to read from the buffer, 0 otherwise.
-*/
+ */
 int buffer_read_int8(read_buffer_t *buffer, int8_t *data);
 
 /**
@@ -160,9 +166,9 @@ int buffer_read_int8(read_buffer_t *buffer, int8_t *data);
  *
  * @param[in] buffer The buffer to write to.
  * @param[in] data The data to write.
- * @return 1 if there is not enough room in the buffer to write the data, 0 otherwise.
-*/
+ * @return 1 if there is not enough room in the buffer to write the data, 0
+ * otherwise.
+ */
 int buffer_write_int8(write_buffer_t *buffer, int8_t data);
 
-
-#endif // __BUFFER_H__
+#endif  // __BUFFER_H__

--- a/components/lightsnapcast/CMakeLists.txt
+++ b/components/lightsnapcast/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "snapcast.c" 
+idf_component_register(SRCS "snapcast.c"
                        INCLUDE_DIRS "include"
                        REQUIRES libbuffer json)

--- a/components/lightsnapcast/include/snapcast.h
+++ b/components/lightsnapcast/include/snapcast.h
@@ -1,35 +1,35 @@
 #ifndef __SNAPCAST_H__
 #define __SNAPCAST_H__
 
-#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 enum message_type {
-    SNAPCAST_MESSAGE_BASE = 0,
-    SNAPCAST_MESSAGE_CODEC_HEADER = 1,
-    SNAPCAST_MESSAGE_WIRE_CHUNK = 2,
-    SNAPCAST_MESSAGE_SERVER_SETTINGS = 3,
-    SNAPCAST_MESSAGE_TIME = 4,
-    SNAPCAST_MESSAGE_HELLO = 5,
-    SNAPCAST_MESSAGE_STREAM_TAGS = 6,
+  SNAPCAST_MESSAGE_BASE = 0,
+  SNAPCAST_MESSAGE_CODEC_HEADER = 1,
+  SNAPCAST_MESSAGE_WIRE_CHUNK = 2,
+  SNAPCAST_MESSAGE_SERVER_SETTINGS = 3,
+  SNAPCAST_MESSAGE_TIME = 4,
+  SNAPCAST_MESSAGE_HELLO = 5,
+  SNAPCAST_MESSAGE_STREAM_TAGS = 6,
 
-    SNAPCAST_MESSAGE_FIRST = SNAPCAST_MESSAGE_BASE,
-    SNAPCAST_MESSAGE_LAST = SNAPCAST_MESSAGE_STREAM_TAGS
+  SNAPCAST_MESSAGE_FIRST = SNAPCAST_MESSAGE_BASE,
+  SNAPCAST_MESSAGE_LAST = SNAPCAST_MESSAGE_STREAM_TAGS
 };
 
 typedef struct tv {
-    int32_t sec;
-    int32_t usec;
+  int32_t sec;
+  int32_t usec;
 } tv_t;
 
 typedef struct base_message {
-    uint16_t type;
-    uint16_t id;
-    uint16_t refersTo;
-    tv_t sent;
-    tv_t received;
-    uint32_t size;
+  uint16_t type;
+  uint16_t id;
+  uint16_t refersTo;
+  tv_t sent;
+  tv_t received;
+  uint32_t size;
 } base_message_t;
 
 extern const int BASE_MESSAGE_SIZE;
@@ -37,7 +37,8 @@ extern const int TIME_MESSAGE_SIZE;
 
 int base_message_serialize(base_message_t *msg, char *data, uint32_t size);
 
-int base_message_deserialize(base_message_t *msg, const char *data, uint32_t size);
+int base_message_deserialize(base_message_t *msg, const char *data,
+                             uint32_t size);
 
 /* Sample Hello message
 {
@@ -54,55 +55,56 @@ int base_message_deserialize(base_message_t *msg, const char *data, uint32_t siz
 */
 
 typedef struct hello_message {
-    char *mac;
-    char *hostname;
-    char *version;
-    char *client_name;
-    char *os;
-    char *arch;
-    int instance;
-    char *id;
-    int protocol_version;
+  char *mac;
+  char *hostname;
+  char *version;
+  char *client_name;
+  char *os;
+  char *arch;
+  int instance;
+  char *id;
+  int protocol_version;
 } hello_message_t;
 
-char* hello_message_serialize(hello_message_t* msg, size_t *size);
+char *hello_message_serialize(hello_message_t *msg, size_t *size);
 
 typedef struct server_settings_message {
-    int32_t buffer_ms;
-    int32_t latency;
-    uint32_t volume;
-    bool muted;
+  int32_t buffer_ms;
+  int32_t latency;
+  uint32_t volume;
+  bool muted;
 } server_settings_message_t;
 
-int server_settings_message_deserialize(server_settings_message_t *msg, const char *json_str);
+int server_settings_message_deserialize(server_settings_message_t *msg,
+                                        const char *json_str);
 
 typedef struct codec_header_message {
-   char *codec;
-   uint32_t size;
-   char *payload;
+  char *codec;
+  uint32_t size;
+  char *payload;
 } codec_header_message_t;
 
-int codec_header_message_deserialize(codec_header_message_t *msg, const char *data, uint32_t size);
+int codec_header_message_deserialize(codec_header_message_t *msg,
+                                     const char *data, uint32_t size);
 void codec_header_message_free(codec_header_message_t *msg);
 
 typedef struct wire_chunk_message {
-    tv_t timestamp;
-    uint32_t size;
-    char *payload;
+  tv_t timestamp;
+  uint32_t size;
+  char *payload;
 } wire_chunk_message_t;
 
 // TODO currently copies, could be made to not copy probably
-int wire_chunk_message_deserialize(wire_chunk_message_t *msg, const char *data, uint32_t size);
+int wire_chunk_message_deserialize(wire_chunk_message_t *msg, const char *data,
+                                   uint32_t size);
 void wire_chunk_message_free(wire_chunk_message_t *msg);
 
 typedef struct time_message {
-    tv_t latency;
+  tv_t latency;
 } time_message_t;
 
 int time_message_serialize(time_message_t *msg, char *data, uint32_t size);
-int time_message_deserialize(time_message_t *msg, const char *data, uint32_t size);
+int time_message_deserialize(time_message_t *msg, const char *data,
+                             uint32_t size);
 
-
-
-
-#endif // __SNAPCAST_H__
+#endif  // __SNAPCAST_H__

--- a/components/lightsnapcast/snapcast.c
+++ b/components/lightsnapcast/snapcast.c
@@ -7,303 +7,311 @@
 //#include "json/cJSON.h"
 //#endif
 
+#include <buffer.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
-#include <buffer.h>
 
 const int BASE_MESSAGE_SIZE = 26;
 const int TIME_MESSAGE_SIZE = 8;
 
 int base_message_serialize(base_message_t *msg, char *data, uint32_t size) {
-    write_buffer_t buffer;
-    int result = 0;
+  write_buffer_t buffer;
+  int result = 0;
 
-    buffer_write_init(&buffer, data, size);
+  buffer_write_init(&buffer, data, size);
 
-    result |= buffer_write_uint16(&buffer, msg->type);
-    result |= buffer_write_uint16(&buffer, msg->id);
-    result |= buffer_write_uint16(&buffer, msg->refersTo);
-    result |= buffer_write_int32(&buffer, msg->sent.sec);
-    result |= buffer_write_int32(&buffer, msg->sent.usec);
-    result |= buffer_write_int32(&buffer, msg->received.sec);
-    result |= buffer_write_int32(&buffer, msg->received.usec);
-    result |= buffer_write_uint32(&buffer, msg->size);
+  result |= buffer_write_uint16(&buffer, msg->type);
+  result |= buffer_write_uint16(&buffer, msg->id);
+  result |= buffer_write_uint16(&buffer, msg->refersTo);
+  result |= buffer_write_int32(&buffer, msg->sent.sec);
+  result |= buffer_write_int32(&buffer, msg->sent.usec);
+  result |= buffer_write_int32(&buffer, msg->received.sec);
+  result |= buffer_write_int32(&buffer, msg->received.usec);
+  result |= buffer_write_uint32(&buffer, msg->size);
 
-    return result;
+  return result;
 }
 
-int base_message_deserialize(base_message_t *msg, const char *data, uint32_t size) {
-    read_buffer_t buffer;
-    int result = 0;
+int base_message_deserialize(base_message_t *msg, const char *data,
+                             uint32_t size) {
+  read_buffer_t buffer;
+  int result = 0;
 
-    buffer_read_init(&buffer, data, size);
+  buffer_read_init(&buffer, data, size);
 
-    result |= buffer_read_uint16(&buffer, &(msg->type));
-    result |= buffer_read_uint16(&buffer, &(msg->id));
-    result |= buffer_read_uint16(&buffer, &(msg->refersTo));
-    result |= buffer_read_int32(&buffer, &(msg->sent.sec));
-    result |= buffer_read_int32(&buffer, &(msg->sent.usec));
-    result |= buffer_read_int32(&buffer, &(msg->received.sec));
-    result |= buffer_read_int32(&buffer, &(msg->received.usec));
-    result |= buffer_read_uint32(&buffer, &(msg->size));
+  result |= buffer_read_uint16(&buffer, &(msg->type));
+  result |= buffer_read_uint16(&buffer, &(msg->id));
+  result |= buffer_read_uint16(&buffer, &(msg->refersTo));
+  result |= buffer_read_int32(&buffer, &(msg->sent.sec));
+  result |= buffer_read_int32(&buffer, &(msg->sent.usec));
+  result |= buffer_read_int32(&buffer, &(msg->received.sec));
+  result |= buffer_read_int32(&buffer, &(msg->received.usec));
+  result |= buffer_read_uint32(&buffer, &(msg->size));
 
-    return result;
+  return result;
 }
 
-static cJSON* hello_message_to_json(hello_message_t *msg) {
-    cJSON *mac;
-    cJSON *hostname;
-    cJSON *version;
-    cJSON *client_name;
-    cJSON *os;
-    cJSON *arch;
-    cJSON *instance;
-    cJSON *id;
-    cJSON *protocol_version;
-    cJSON *json = NULL;
+static cJSON *hello_message_to_json(hello_message_t *msg) {
+  cJSON *mac;
+  cJSON *hostname;
+  cJSON *version;
+  cJSON *client_name;
+  cJSON *os;
+  cJSON *arch;
+  cJSON *instance;
+  cJSON *id;
+  cJSON *protocol_version;
+  cJSON *json = NULL;
 
-    json = cJSON_CreateObject();
-    if (!json) {
-        goto error;
-    }
+  json = cJSON_CreateObject();
+  if (!json) {
+    goto error;
+  }
 
-    mac = cJSON_CreateString(msg->mac);
-    if (!mac) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "MAC", mac);
+  mac = cJSON_CreateString(msg->mac);
+  if (!mac) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "MAC", mac);
 
-    hostname = cJSON_CreateString(msg->hostname);
-    if (!hostname) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "HostName", hostname);
+  hostname = cJSON_CreateString(msg->hostname);
+  if (!hostname) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "HostName", hostname);
 
-    version = cJSON_CreateString(msg->version);
-    if (!version) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "Version", version);
+  version = cJSON_CreateString(msg->version);
+  if (!version) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "Version", version);
 
-    client_name = cJSON_CreateString(msg->client_name);
-    if (!client_name) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "ClientName", client_name);
+  client_name = cJSON_CreateString(msg->client_name);
+  if (!client_name) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "ClientName", client_name);
 
-    os = cJSON_CreateString(msg->os);
-    if (!os) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "OS", os);
+  os = cJSON_CreateString(msg->os);
+  if (!os) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "OS", os);
 
-    arch = cJSON_CreateString(msg->arch);
-    if (!arch) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "Arch", arch);
+  arch = cJSON_CreateString(msg->arch);
+  if (!arch) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "Arch", arch);
 
-    instance = cJSON_CreateNumber(msg->instance);
-    if (!instance) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "Instance", instance);
+  instance = cJSON_CreateNumber(msg->instance);
+  if (!instance) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "Instance", instance);
 
-    id = cJSON_CreateString(msg->id);
-    if (!id) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "ID", id);
+  id = cJSON_CreateString(msg->id);
+  if (!id) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "ID", id);
 
-    protocol_version = cJSON_CreateNumber(msg->protocol_version);
-    if (!protocol_version) {
-        goto error;
-    }
-    cJSON_AddItemToObject(json, "SnapStreamProtocolVersion", protocol_version);
+  protocol_version = cJSON_CreateNumber(msg->protocol_version);
+  if (!protocol_version) {
+    goto error;
+  }
+  cJSON_AddItemToObject(json, "SnapStreamProtocolVersion", protocol_version);
 
-    goto end;
+  goto end;
 error:
-    cJSON_Delete(json);
+  cJSON_Delete(json);
 
 end:
-    return json;
+  return json;
 }
 
-char* hello_message_serialize(hello_message_t* msg, size_t *size) {
-    int str_length, prefixed_length;
-    cJSON *json;
-    char *str = NULL;
-	char *prefixed_str = NULL;
+char *hello_message_serialize(hello_message_t *msg, size_t *size) {
+  int str_length, prefixed_length;
+  cJSON *json;
+  char *str = NULL;
+  char *prefixed_str = NULL;
 
-    json = hello_message_to_json(msg);
-    if (!json) {
-        return NULL;
-    }
+  json = hello_message_to_json(msg);
+  if (!json) {
+    return NULL;
+  }
 
-    str = cJSON_PrintUnformatted(json);
-	if (!str) {
-		return NULL;
-	}
-    cJSON_Delete(json);
+  str = cJSON_PrintUnformatted(json);
+  if (!str) {
+    return NULL;
+  }
+  cJSON_Delete(json);
 
-	str_length = strlen(str);
-	prefixed_length = str_length + 4;
-	prefixed_str = malloc(prefixed_length);
-	if (!prefixed_str) {
-		return NULL;
-	}
+  str_length = strlen(str);
+  prefixed_length = str_length + 4;
+  prefixed_str = malloc(prefixed_length);
+  if (!prefixed_str) {
+    return NULL;
+  }
 
-	prefixed_str[0] = str_length & 0xff;
-	prefixed_str[1] = (str_length >> 8) & 0xff;
-	prefixed_str[2] = (str_length >> 16) & 0xff;
-	prefixed_str[3] = (str_length >> 24) & 0xff;
-	memcpy(&(prefixed_str[4]), str, str_length);
-	free(str);
-	*size = prefixed_length;
+  prefixed_str[0] = str_length & 0xff;
+  prefixed_str[1] = (str_length >> 8) & 0xff;
+  prefixed_str[2] = (str_length >> 16) & 0xff;
+  prefixed_str[3] = (str_length >> 24) & 0xff;
+  memcpy(&(prefixed_str[4]), str, str_length);
+  free(str);
+  *size = prefixed_length;
 
-    return prefixed_str;
+  return prefixed_str;
 }
 
-int server_settings_message_deserialize(server_settings_message_t *msg, const char *json_str) {
-    int status = 1;
-    cJSON *value = NULL;
-    cJSON *json = cJSON_Parse(json_str);
-    if (!json) {
-        const char *error_ptr = cJSON_GetErrorPtr();
-        if (error_ptr) {
-            // TODO change to a macro that can be diabled
-            fprintf(stderr, "Error before: %s\n", error_ptr);
-            goto end;
-        }
+int server_settings_message_deserialize(server_settings_message_t *msg,
+                                        const char *json_str) {
+  int status = 1;
+  cJSON *value = NULL;
+  cJSON *json = cJSON_Parse(json_str);
+  if (!json) {
+    const char *error_ptr = cJSON_GetErrorPtr();
+    if (error_ptr) {
+      // TODO change to a macro that can be disabled
+      fprintf(stderr, "Error before: %s\n", error_ptr);
+      goto end;
     }
+  }
 
-    if (msg == NULL) {
-        status = 2;
-        goto end;
-    }
+  if (msg == NULL) {
+    status = 2;
+    goto end;
+  }
 
-    value = cJSON_GetObjectItemCaseSensitive(json, "bufferMs");
-    if (cJSON_IsNumber(value)) {
-        msg->buffer_ms = value->valueint;
-    }
+  value = cJSON_GetObjectItemCaseSensitive(json, "bufferMs");
+  if (cJSON_IsNumber(value)) {
+    msg->buffer_ms = value->valueint;
+  }
 
-    value = cJSON_GetObjectItemCaseSensitive(json, "latency");
-    if (cJSON_IsNumber(value)) {
-        msg->latency = value->valueint;
-    }
+  value = cJSON_GetObjectItemCaseSensitive(json, "latency");
+  if (cJSON_IsNumber(value)) {
+    msg->latency = value->valueint;
+  }
 
-    value = cJSON_GetObjectItemCaseSensitive(json, "volume");
-    if (cJSON_IsNumber(value)) {
-        msg->volume = value->valueint;
-    }
+  value = cJSON_GetObjectItemCaseSensitive(json, "volume");
+  if (cJSON_IsNumber(value)) {
+    msg->volume = value->valueint;
+  }
 
-    value = cJSON_GetObjectItemCaseSensitive(json, "muted");
-    msg->muted = cJSON_IsTrue(value);
-    status = 0;
+  value = cJSON_GetObjectItemCaseSensitive(json, "muted");
+  msg->muted = cJSON_IsTrue(value);
+  status = 0;
 end:
-    cJSON_Delete(json);
-    return status;
+  cJSON_Delete(json);
+  return status;
 }
 
-int codec_header_message_deserialize(codec_header_message_t *msg, const char *data, uint32_t size) {
-    read_buffer_t buffer;
-    uint32_t string_size;
-    int result = 0;
+int codec_header_message_deserialize(codec_header_message_t *msg,
+                                     const char *data, uint32_t size) {
+  read_buffer_t buffer;
+  uint32_t string_size;
+  int result = 0;
 
-    buffer_read_init(&buffer, data, size);
+  buffer_read_init(&buffer, data, size);
 
-    result |= buffer_read_uint32(&buffer, &string_size);
-    if (result) {
-        // Can't allocate the proper size string if we didn't read the size, so fail early
-        return 1;
-    }
+  result |= buffer_read_uint32(&buffer, &string_size);
+  if (result) {
+    // Can't allocate the proper size string if we didn't read the size, so fail
+    // early
+    return 1;
+  }
 
-    msg->codec = malloc(string_size + 1);
-    if (!msg->codec) {
-        return 2;
-    }
+  msg->codec = malloc(string_size + 1);
+  if (!msg->codec) {
+    return 2;
+  }
 
-    result |= buffer_read_buffer(&buffer, msg->codec, string_size);
-    // Make sure the codec is a proper C string by terminating it with a null character
-    msg->codec[string_size] = '\0';
+  result |= buffer_read_buffer(&buffer, msg->codec, string_size);
+  // Make sure the codec is a proper C string by terminating it with a null
+  // character
+  msg->codec[string_size] = '\0';
 
-    result |= buffer_read_uint32(&buffer, &(msg->size));
-    if (result) {
-        // Can't allocate the proper size string if we didn't read the size, so fail early
-        return 1;
-    }
+  result |= buffer_read_uint32(&buffer, &(msg->size));
+  if (result) {
+    // Can't allocate the proper size string if we didn't read the size, so fail
+    // early
+    return 1;
+  }
 
-    msg->payload = malloc(msg->size);
-    if (!msg->payload) {
-        return 2;
-    }
+  msg->payload = malloc(msg->size);
+  if (!msg->payload) {
+    return 2;
+  }
 
-    result |= buffer_read_buffer(&buffer, msg->payload, msg->size);
-    return result;
+  result |= buffer_read_buffer(&buffer, msg->payload, msg->size);
+  return result;
 }
 
-int wire_chunk_message_deserialize(wire_chunk_message_t *msg, const char *data, uint32_t size) {
-    read_buffer_t buffer;
-    int result = 0;
+int wire_chunk_message_deserialize(wire_chunk_message_t *msg, const char *data,
+                                   uint32_t size) {
+  read_buffer_t buffer;
+  int result = 0;
 
-    buffer_read_init(&buffer, data, size);
+  buffer_read_init(&buffer, data, size);
 
-    result |= buffer_read_int32(&buffer, &(msg->timestamp.sec));
-    result |= buffer_read_int32(&buffer, &(msg->timestamp.usec));
-    result |= buffer_read_uint32(&buffer, &(msg->size));
+  result |= buffer_read_int32(&buffer, &(msg->timestamp.sec));
+  result |= buffer_read_int32(&buffer, &(msg->timestamp.usec));
+  result |= buffer_read_uint32(&buffer, &(msg->size));
 
-    // If there's been an error already (especially for the size bit) return early
-    if (result) {
-        return result;
-    }
-
-    // TODO maybe should check to see if need to free memory?
-    msg->payload = malloc(msg->size * sizeof(char));
-    // Failed to allocate the memory
-    if (!msg->payload) {
-        return 2;
-    }
-
-    result |= buffer_read_buffer(&buffer, msg->payload, msg->size);
+  // If there's been an error already (especially for the size bit) return early
+  if (result) {
     return result;
+  }
+
+  // TODO maybe should check to see if need to free memory?
+  msg->payload = malloc(msg->size * sizeof(char));
+  // Failed to allocate the memory
+  if (!msg->payload) {
+    return 2;
+  }
+
+  result |= buffer_read_buffer(&buffer, msg->payload, msg->size);
+  return result;
 }
 
 void codec_header_message_free(codec_header_message_t *msg) {
-    free(msg->codec);
-    msg->codec = NULL;
-    free(msg->payload);
-    msg->payload = NULL;
+  free(msg->codec);
+  msg->codec = NULL;
+  free(msg->payload);
+  msg->payload = NULL;
 }
 
 void wire_chunk_message_free(wire_chunk_message_t *msg) {
-    if (msg->payload) {
-        free(msg->payload);
-        msg->payload = NULL;
-    }
+  if (msg->payload) {
+    free(msg->payload);
+    msg->payload = NULL;
+  }
 }
 
 int time_message_serialize(time_message_t *msg, char *data, uint32_t size) {
-    write_buffer_t buffer;
-    int result = 0;
+  write_buffer_t buffer;
+  int result = 0;
 
-    buffer_write_init(&buffer, data, size);
+  buffer_write_init(&buffer, data, size);
 
-    result |= buffer_write_int32(&buffer, msg->latency.sec);
-    result |= buffer_write_int32(&buffer, msg->latency.usec);
+  result |= buffer_write_int32(&buffer, msg->latency.sec);
+  result |= buffer_write_int32(&buffer, msg->latency.usec);
 
-    return result;
+  return result;
 }
 
-int time_message_deserialize(time_message_t *msg, const char *data, uint32_t size) {
-    read_buffer_t buffer;
-    int result = 0;
+int time_message_deserialize(time_message_t *msg, const char *data,
+                             uint32_t size) {
+  read_buffer_t buffer;
+  int result = 0;
 
-    buffer_read_init(&buffer, data, size);
+  buffer_read_init(&buffer, data, size);
 
-    result |= buffer_read_int32(&buffer, &(msg->latency.sec));
-    result |= buffer_read_int32(&buffer, &(msg->latency.usec));
+  result |= buffer_read_int32(&buffer, &(msg->latency.sec));
+  result |= buffer_read_int32(&buffer, &(msg->latency.usec));
 
-    return result;
+  return result;
 }

--- a/components/net_functions/CMakeLists.txt
+++ b/components/net_functions/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "net_functions.c" 
+idf_component_register(SRCS "net_functions.c"
                        INCLUDE_DIRS "include"
                        REQUIRES mdns wifi_interface)

--- a/components/net_functions/component.mk
+++ b/components/net_functions/component.mk
@@ -1,8 +1,8 @@
 #
 # Main Makefile. This is basically the same as a component makefile.
 #
-# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default, 
-# this will take the sources in the src/ directory, compile them and link them into 
+# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default,
+# this will take the sources in the src/ directory, compile them and link them into
 # lib(subdirectory_name).a in the build directory. This behaviour is entirely configurable,
 # please read the ESP-IDF documents if you need to do this.
 #

--- a/components/net_functions/include/net_functions.h
+++ b/components/net_functions/include/net_functions.h
@@ -5,13 +5,12 @@
 
 #define SNTP_TIMEZONE CONFIG_SNTP_TIMEZONE
 
-void net_mdns_register(const char * clientname);
-void mdns_print_results(mdns_result_t * results);
+void net_mdns_register(const char* clientname);
+void mdns_print_results(mdns_result_t* results);
 
 // Return port number
-uint32_t find_mdns_service(const char * service_name, const char * proto);
+uint32_t find_mdns_service(const char* service_name, const char* proto);
 
 void set_time_from_sntp(void);
-
 
 #endif /* _NET_FUNCTIONS_H_ */

--- a/components/net_functions/net_functions.c
+++ b/components/net_functions/net_functions.c
@@ -2,97 +2,95 @@
    Network related functions
 */
 
-#include <string.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/event_groups.h"
-#include "esp_system.h"
-#include "esp_event.h"
-#include "esp_log.h"
-#include "esp_wifi.h"
-#include "esp_netif.h"
-#include "mdns.h"
-#include "esp_sntp.h"
-
-#include "driver/gpio.h"
-#include "netdb.h"
-
-#include "wifi_interface.h"
 #include "net_functions.h"
 
+#include <string.h>
 
+#include "driver/gpio.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_sntp.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+#include "mdns.h"
+#include "netdb.h"
+#include "wifi_interface.h"
 
 static const char *TAG = "NETF";
 
 extern EventGroupHandle_t s_wifi_event_group;
 
-static const char * if_str[] = {"STA", "AP", "ETH", "MAX"};
-static const char * ip_protocol_str[] = {"V4", "V6", "MAX"};
+static const char *if_str[] = {"STA", "AP", "ETH", "MAX"};
+static const char *ip_protocol_str[] = {"V4", "V6", "MAX"};
 
-void net_mdns_register(const char * clientname) {
-    ESP_LOGI(TAG, "Setup mdns");
-    ESP_ERROR_CHECK( mdns_init() );
-    ESP_ERROR_CHECK( mdns_hostname_set(clientname) );
-	ESP_ERROR_CHECK( mdns_instance_name_set("ESP32 SNAPcast client OTA") );
-    ESP_ERROR_CHECK( mdns_service_add(NULL, "_http", "_tcp", 8032, NULL, 0)  );
+void net_mdns_register(const char *clientname) {
+  ESP_LOGI(TAG, "Setup mdns");
+  ESP_ERROR_CHECK(mdns_init());
+  ESP_ERROR_CHECK(mdns_hostname_set(clientname));
+  ESP_ERROR_CHECK(mdns_instance_name_set("ESP32 SNAPcast client OTA"));
+  ESP_ERROR_CHECK(mdns_service_add(NULL, "_http", "_tcp", 8032, NULL, 0));
 }
 
-void mdns_print_results(mdns_result_t * results){
-    mdns_result_t * r = results;
-    mdns_ip_addr_t * a = NULL;
-    int i = 1, t;
-    while(r){
-        printf("%d: Interface: %s, Type: %s\n", i++, if_str[r->tcpip_if], ip_protocol_str[r->ip_protocol]);
-        if(r->instance_name){
-            printf("  PTR : %s\n", r->instance_name);
-        }
-        if(r->hostname){
-            printf("  SRV : %s.local:%u\n", r->hostname, r->port);
-        }
-        if(r->txt_count){
-            printf("  TXT : [%u] ", r->txt_count);
-            for(t=0; t<r->txt_count; t++){
-                printf("%s=%s; ", r->txt[t].key, r->txt[t].value);
-            }
-            printf("\n");
-        }
-        a = r->addr;
-        while(a){
-            if(a->addr.type == IPADDR_TYPE_V6){
-                printf("  AAAA: " IPV6STR "\n", IPV62STR(a->addr.u_addr.ip6));
-            } else {
-                printf("  A   : " IPSTR "\n", IP2STR(&(a->addr.u_addr.ip4)));
-            }
-            a = a->next;
-        }
-        r = r->next;
+void mdns_print_results(mdns_result_t *results) {
+  mdns_result_t *r = results;
+  mdns_ip_addr_t *a = NULL;
+  int i = 1, t;
+  while (r) {
+    printf("%d: Interface: %s, Type: %s\n", i++, if_str[r->tcpip_if],
+           ip_protocol_str[r->ip_protocol]);
+    if (r->instance_name) {
+      printf("  PTR : %s\n", r->instance_name);
     }
+    if (r->hostname) {
+      printf("  SRV : %s.local:%u\n", r->hostname, r->port);
+    }
+    if (r->txt_count) {
+      printf("  TXT : [%u] ", r->txt_count);
+      for (t = 0; t < r->txt_count; t++) {
+        printf("%s=%s; ", r->txt[t].key, r->txt[t].value);
+      }
+      printf("\n");
+    }
+    a = r->addr;
+    while (a) {
+      if (a->addr.type == IPADDR_TYPE_V6) {
+        printf("  AAAA: " IPV6STR "\n", IPV62STR(a->addr.u_addr.ip6));
+      } else {
+        printf("  A   : " IPSTR "\n", IP2STR(&(a->addr.u_addr.ip4)));
+      }
+      a = a->next;
+    }
+    r = r->next;
+  }
 }
 
-uint32_t find_mdns_service(const char * service_name, const char * proto)
-{
-    ESP_LOGI(TAG, "Query PTR: %s.%s.local", service_name, proto);
+uint32_t find_mdns_service(const char *service_name, const char *proto) {
+  ESP_LOGI(TAG, "Query PTR: %s.%s.local", service_name, proto);
 
-    mdns_result_t * r = NULL;
-    esp_err_t err = mdns_query_ptr(service_name, proto, 3000, 20,  &r);
-    if(err){
-        ESP_LOGE(TAG, "Query Failed");
-        return -1;
-    }
-    if(!r){
-        ESP_LOGW(TAG, "No results found!");
-        return -1;
-    }
+  mdns_result_t *r = NULL;
+  esp_err_t err = mdns_query_ptr(service_name, proto, 3000, 20, &r);
+  if (err) {
+    ESP_LOGE(TAG, "Query Failed");
+    return -1;
+  }
+  if (!r) {
+    ESP_LOGW(TAG, "No results found!");
+    return -1;
+  }
 
-    if(r->instance_name){
-            printf("  PTR : %s\n", r->instance_name);
-    }
-    if(r->hostname){
-            printf("  SRV : %s.local:%u\n", r->hostname, r->port);
-      return r->port;
-    }
-    mdns_query_results_free(r);
-    return 0;
+  if (r->instance_name) {
+    printf("  PTR : %s\n", r->instance_name);
+  }
+  if (r->hostname) {
+    printf("  SRV : %s.local:%u\n", r->hostname, r->port);
+    return r->port;
+  }
+  mdns_query_results_free(r);
+  return 0;
 }
 static int sntp_synced = 0;
 
@@ -109,44 +107,45 @@ void sntp_sync_time(struct timeval *tv_ntp) {
   gettimeofday(&tv_esp, NULL);
   //ESP_LOGI(TAG,"SNTP diff  s: %ld , %ld ", tv_esp.tv_sec , tv_ntp->tv_sec);
   ESP_LOGI(TAG,"SNTP diff us: %ld , %ld ", tv_esp.tv_usec , tv_ntp->tv_usec);
-  ESP_LOGI(TAG,"SNTP diff us: %.2f", (double)((tv_esp.tv_usec - tv_ntp->tv_usec)/1000.0));
+  ESP_LOGI(TAG,"SNTP diff us: %.2f", (double)((tv_esp.tv_usec -
+tv_ntp->tv_usec)/1000.0));
 
 }*/
 
-void sntp_cb(struct timeval *tv)
-{   struct tm timeinfo = { 0 };
-    time_t now = tv->tv_sec;
-    localtime_r(&now, &timeinfo);
-    char strftime_buf[64];
-    strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
-    ESP_LOGI(TAG, "sntp_cb called :%s", strftime_buf);
+void sntp_cb(struct timeval *tv) {
+  struct tm timeinfo = {0};
+  time_t now = tv->tv_sec;
+  localtime_r(&now, &timeinfo);
+  char strftime_buf[64];
+  strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
+  ESP_LOGI(TAG, "sntp_cb called :%s", strftime_buf);
 }
 
 void set_time_from_sntp() {
-    xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT,
-                        false, true, portMAX_DELAY);
-    //ESP_LOGI(TAG, "clock %");
-    ESP_LOGI(TAG, "Initializing SNTP");
-    sntp_setoperatingmode(SNTP_OPMODE_POLL);
-	sntp_setservername(0, CONFIG_SNTP_SERVER);
-    sntp_init();
-    //sntp_set_time_sync_notification_cb(sntp_cb);
-    setenv("TZ", SNTP_TIMEZONE, 1);
-    tzset();
+  xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, false, true,
+                      portMAX_DELAY);
+  // ESP_LOGI(TAG, "clock %");
+  ESP_LOGI(TAG, "Initializing SNTP");
+  sntp_setoperatingmode(SNTP_OPMODE_POLL);
+  sntp_setservername(0, CONFIG_SNTP_SERVER);
+  sntp_init();
+  // sntp_set_time_sync_notification_cb(sntp_cb);
+  setenv("TZ", SNTP_TIMEZONE, 1);
+  tzset();
 
-    time_t now = 0;
-    struct tm timeinfo = { 0 };
-    int retry = 0;
-    const int retry_count = 10;
-    while(timeinfo.tm_year < (2016 - 1900) && ++retry < retry_count) {
-        ESP_LOGI(TAG, "Waiting for system time to be set... (%d/%d)", retry, retry_count);
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-        time(&now);
-        localtime_r(&now, &timeinfo);
-    }
-    char strftime_buf[64];
+  time_t now = 0;
+  struct tm timeinfo = {0};
+  int retry = 0;
+  const int retry_count = 10;
+  while (timeinfo.tm_year < (2016 - 1900) && ++retry < retry_count) {
+    ESP_LOGI(TAG, "Waiting for system time to be set... (%d/%d)", retry,
+             retry_count);
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+    time(&now);
+    localtime_r(&now, &timeinfo);
+  }
+  char strftime_buf[64];
 
-    strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
-    ESP_LOGI(TAG, "The current date/time in UTC is: %s", strftime_buf);
-
+  strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
+  ESP_LOGI(TAG, "The current date/time in UTC is: %s", strftime_buf);
 }

--- a/components/opus/CMakeLists.txt
+++ b/components/opus/CMakeLists.txt
@@ -6,15 +6,13 @@ file(GLOB float "opus/slik/float/*.c")
 
 
 idf_component_register(SRCS "${srcs}" "${silk}" "${celt}" "${fixed}" "${float}"
-                       INCLUDE_DIRS . 
+                       INCLUDE_DIRS .
 					                "opus/include"
-									"opus/silk"  
+									"opus/silk"
 									"opus/silk/fixed"
 									"opus/silk/float"
-									"opus/celt" 
+									"opus/celt"
 									)
 
 
 target_compile_definitions(${COMPONENT_TARGET} PRIVATE "-DHAVE_CONFIG_H")
-									
-									

--- a/components/opus/component.mk
+++ b/components/opus/component.mk
@@ -1,12 +1,12 @@
 #
 # Main Makefile. This is basically the same as a component makefile.
 #
-# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default, 
-# this will take the sources in the src/ directory, compile them and link them into 
+# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default,
+# this will take the sources in the src/ directory, compile them and link them into
 # lib(subdirectory_name).a in the build directory. This behaviour is entirely configurable,
 # please read the ESP-IDF documents if you need to do this.
 #
 
-COMPONENT_SRCDIRS := opus/src opus/silk opus/silk/fixed opus/celt 
+COMPONENT_SRCDIRS := opus/src opus/silk opus/silk/fixed opus/celt
 COMPONENT_ADD_INCLUDEDIRS := . opus/include opus/silk opus/silk/fixed opus/celt
 CFLAGS += -DHAVE_CONFIG_H

--- a/components/opus/config.h
+++ b/components/opus/config.h
@@ -48,7 +48,7 @@
 
 /* Define to 1 if you have the `lrint' function. */
 /* #undef HAVE_LRINT */
-#define  HAVE_LRINT 1
+#define HAVE_LRINT 1
 /* Define to 1 if you have the `lrintf' function. */
 /* #undef HAVE_LRINTF */
 #define HAVE_LRINTF 1
@@ -203,6 +203,6 @@
    previous line.  Perhaps some future version of Sun C++ will work with
    restrict; if so, hopefully it defines __RESTRICT like Sun C does.  */
 #if defined __SUNPRO_CC && !defined __RESTRICT
-# define _Restrict
-# define __restrict__
+#define _Restrict
+#define __restrict__
 #endif

--- a/components/ota_server/CMakeLists.txt
+++ b/components/ota_server/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "ota_server.c" 
+idf_component_register(SRCS "ota_server.c"
                        INCLUDE_DIRS "include"
                        REQUIRES app_update dsp_processor)

--- a/components/ota_server/component.mk
+++ b/components/ota_server/component.mk
@@ -1,8 +1,8 @@
 #
 # Main Makefile. This is basically the same as a component makefile.
 #
-# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default, 
-# this will take the sources in the src/ directory, compile them and link them into 
+# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default,
+# this will take the sources in the src/ directory, compile them and link them into
 # lib(subdirectory_name).a in the build directory. This behaviour is entirely configurable,
 # please read the ESP-IDF documents if you need to do this.
 #

--- a/components/ota_server/include/ota_server.h
+++ b/components/ota_server/include/ota_server.h
@@ -3,9 +3,7 @@
 #define OTA_LISTEN_PORT 8032
 #define OTA_BUFF_SIZE 1024
 
-
 extern const int OTA_CONNECTED_BIT;
-
 
 void ota_server_task(void *param);
 void ota_server_start_my(void);

--- a/components/ota_server/ota_server.c
+++ b/components/ota_server/ota_server.c
@@ -1,264 +1,252 @@
-//https://github.com/yanbe/esp-idf-ota-template/blob/master/components/ota_server/ota_server.c
-
-
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/event_groups.h"
-#include "esp_event.h"
+// https://github.com/yanbe/esp-idf-ota-template/blob/master/components/ota_server/ota_server.c
 
 #include "ota_server.h"
 
-#define FIRMWARE_REV    " Rev: 0.1"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include "esp_event.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
 
-#include "esp_wifi.h"
-#include "esp_system.h"
-#include "esp_log.h"
-#include "esp_ota_ops.h"
-#include "lwip/sockets.h"
+#define FIRMWARE_REV " Rev: 0.1"
 
 #include "dsp_processor.h"
+#include "esp_log.h"
+#include "esp_ota_ops.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "lwip/sockets.h"
 
 extern xTaskHandle t_http_get_task;
 
 const int OTA_CONNECTED_BIT = BIT0;
-static const char * TAG = "OTA";
+static const char *TAG = "OTA";
 EventGroupHandle_t ota_event_group;
 /*socket*/
 static int connect_socket = 0;
 
-void ota_server_task(void *param)
-{
-	//xEventGroupWaitBits(ota_event_group, OTA_CONNECTED_BIT, false, true, portMAX_DELAY);
-	ota_server_start_my();
-	vTaskDelete(NULL);
+void ota_server_task(void *param) {
+  // xEventGroupWaitBits(ota_event_group, OTA_CONNECTED_BIT, false, true,
+  // portMAX_DELAY);
+  ota_server_start_my();
+  vTaskDelete(NULL);
 }
 
 /*
 static esp_err_t event_handler(void *ctx, system_event_t *event)
 {
-	switch (event->event_id)
-	{
-	case SYSTEM_EVENT_STA_START:
-		esp_wifi_connect();
-        printf("Connectiing To SSID:%s : Pass:%s\r\n", CONFIG_STATION_SSID, CONFIG_STATION_PASSPHRASE);
-		break;
-	case SYSTEM_EVENT_STA_GOT_IP:
-        printf("got ip:%s",	ip4addr_ntoa(&event->event_info.got_ip.ip_info.ip));
-		xEventGroupSetBits(ota_event_group, OTA_CONNECTED_BIT);
-		break;
-	case SYSTEM_EVENT_STA_DISCONNECTED:
+        switch (event->event_id)
+        {
+        case SYSTEM_EVENT_STA_START:
+                esp_wifi_connect();
+        printf("Connectiing To SSID:%s : Pass:%s\r\n", CONFIG_STATION_SSID,
+CONFIG_STATION_PASSPHRASE); break; case SYSTEM_EVENT_STA_GOT_IP: printf("got
+ip:%s",	ip4addr_ntoa(&event->event_info.got_ip.ip_info.ip));
+                xEventGroupSetBits(ota_event_group, OTA_CONNECTED_BIT);
+                break;
+        case SYSTEM_EVENT_STA_DISCONNECTED:
         printf("SYSTEM_EVENT_STA_DISCONNECTED\r\n");
-		esp_wifi_connect();
-		xEventGroupClearBits(ota_event_group, OTA_CONNECTED_BIT);
-		break;
-	default:
-		break;
-	}
-	return ESP_OK;
+                esp_wifi_connect();
+                xEventGroupClearBits(ota_event_group, OTA_CONNECTED_BIT);
+                break;
+        default:
+                break;
+        }
+        return ESP_OK;
 }
 
 void initialise_wifi(void)
 {
-	ota_event_group = xEventGroupCreate();
+        ota_event_group = xEventGroupCreate();
 
-	tcpip_adapter_init();
-	ESP_ERROR_CHECK(esp_event_loop_init(event_handler, NULL));
-	wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-	ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-	wifi_config_t sta_config = {
-		.sta = {
-			.ssid = CONFIG_STATION_SSID,
-			.password = CONFIG_STATION_PASSPHRASE,
-			.bssid_set = false
-			}
-	};
-	ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-	ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_config));
-	ESP_ERROR_CHECK(esp_wifi_start());
+        tcpip_adapter_init();
+        ESP_ERROR_CHECK(esp_event_loop_init(event_handler, NULL));
+        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+        ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+        wifi_config_t sta_config = {
+                .sta = {
+                        .ssid = CONFIG_STATION_SSID,
+                        .password = CONFIG_STATION_PASSPHRASE,
+                        .bssid_set = false
+                        }
+        };
+        ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_config));
+        ESP_ERROR_CHECK(esp_wifi_start());
 }
 */
 
-static int get_socket_error_code(int socket)
-{
-    int result;
-    u32_t optlen = sizeof(int);
+static int get_socket_error_code(int socket) {
+  int result;
+  u32_t optlen = sizeof(int);
 
-    int err = getsockopt(socket, SOL_SOCKET, SO_ERROR, &result, &optlen);
+  int err = getsockopt(socket, SOL_SOCKET, SO_ERROR, &result, &optlen);
 
-    if (err == -1)
-    {
-        ESP_LOGE(TAG, "getsockopt failed:%s", strerror(err));
-        return -1;
-    }
-    return result;
+  if (err == -1) {
+    ESP_LOGE(TAG, "getsockopt failed:%s", strerror(err));
+    return -1;
+  }
+  return result;
 }
 
-static int show_socket_error_reason(const char *str, int socket)
-{
-    int err = get_socket_error_code(socket);
+static int show_socket_error_reason(const char *str, int socket) {
+  int err = get_socket_error_code(socket);
 
-    if (err != 0)
-    {
-        ESP_LOGW(TAG, "%s socket error %d %s", str, err, strerror(err));
-    }
+  if (err != 0) {
+    ESP_LOGW(TAG, "%s socket error %d %s", str, err, strerror(err));
+  }
 
-    return err;
+  return err;
 }
 
-static esp_err_t create_tcp_server()
-{
-    ESP_LOGI(TAG, "idf.py build ; curl snapclient.local:%d --data-binary @- < build/snapclient.bin", OTA_LISTEN_PORT);
-    int server_socket = 0;
-    struct sockaddr_in server_addr;
-    server_socket = socket(AF_INET, SOCK_STREAM, 0);
+static esp_err_t create_tcp_server() {
+  ESP_LOGI(TAG,
+           "idf.py build ; curl snapclient.local:%d --data-binary @- < "
+           "build/snapclient.bin",
+           OTA_LISTEN_PORT);
+  int server_socket = 0;
+  struct sockaddr_in server_addr;
+  server_socket = socket(AF_INET, SOCK_STREAM, 0);
 
-    if (server_socket < 0)
-    {
-        show_socket_error_reason("create_server", server_socket);
-        return ESP_FAIL;
-    }
+  if (server_socket < 0) {
+    show_socket_error_reason("create_server", server_socket);
+    return ESP_FAIL;
+  }
 
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(OTA_LISTEN_PORT);
-    server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-    if (bind(server_socket, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0)
-    {
-        show_socket_error_reason("bind_server", server_socket);
-        close(server_socket);
-        return ESP_FAIL;
-    }
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(OTA_LISTEN_PORT);
+  server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  if (bind(server_socket, (struct sockaddr *)&server_addr,
+           sizeof(server_addr)) < 0) {
+    show_socket_error_reason("bind_server", server_socket);
+    close(server_socket);
+    return ESP_FAIL;
+  }
 
-    if (listen(server_socket, 5) < 0)
-    {
-        show_socket_error_reason("listen_server", server_socket);
-        close(server_socket);
-        return ESP_FAIL;
-    }
+  if (listen(server_socket, 5) < 0) {
+    show_socket_error_reason("listen_server", server_socket);
+    close(server_socket);
+    return ESP_FAIL;
+  }
 
-    struct sockaddr_in client_addr;
-    unsigned int socklen = sizeof(client_addr);
-    connect_socket = accept(server_socket, (struct sockaddr *)&client_addr, &socklen);
+  struct sockaddr_in client_addr;
+  unsigned int socklen = sizeof(client_addr);
+  connect_socket =
+      accept(server_socket, (struct sockaddr *)&client_addr, &socklen);
 
-    if (connect_socket < 0)
-    {
-        show_socket_error_reason("accept_server", connect_socket);
-        close(server_socket);
-        return ESP_FAIL;
-    }
-    /*connection established，now can send/recv*/
-    ESP_LOGI(TAG, "tcp connection established!");
-    return ESP_OK;
+  if (connect_socket < 0) {
+    show_socket_error_reason("accept_server", connect_socket);
+    close(server_socket);
+    return ESP_FAIL;
+  }
+  /*connection established，now can send/recv*/
+  ESP_LOGI(TAG, "tcp connection established!");
+  return ESP_OK;
 }
 
-void ota_server_start_my(void)
-{
-	uint8_t percent_loaded;
-    uint8_t old_percent_loaded;
+void ota_server_start_my(void) {
+  uint8_t percent_loaded;
+  uint8_t old_percent_loaded;
 
+  ESP_ERROR_CHECK(create_tcp_server());
 
-    ESP_ERROR_CHECK( create_tcp_server() );
+  const esp_partition_t *update_partition =
+      esp_ota_get_next_update_partition(NULL);
 
-    const esp_partition_t *update_partition = esp_ota_get_next_update_partition(NULL);
+  ESP_LOGI(TAG, "Writing to partition subtype %d at offset 0x%x",
+           update_partition->subtype, update_partition->address);
 
-    ESP_LOGI(TAG, "Writing to partition subtype %d at offset 0x%x",	update_partition->subtype, update_partition->address);
+  // https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/log.html
+  // I don't want to see all the Log esp_image stuff while its flashing it
+  esp_log_level_set(
+      "esp_image",
+      ESP_LOG_ERROR);  // set all components to ERROR level  ESP_LOG_NONE
 
-	//https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/log.html
-	// I dont want to see all the Log esp_image stuff while its flashing it
-	esp_log_level_set("esp_image", ESP_LOG_ERROR);           // set all components to ERROR level  ESP_LOG_NONE
+  // We don't want any other thread running during this update.
+  // SuspendAllThreads();
+  // KillAllThreads();
+  dsp_i2s_task_deinit();
+  vTaskDelete(t_http_get_task);
 
+  int recv_len;
+  char ota_buff[OTA_BUFF_SIZE] = {0};
+  bool is_req_body_started = false;
+  int content_length = -1;
+  int content_received = 0;
 
-	// We dont want any other thread running during this update.
-	//SuspendAllThreads();
-	//KillAllThreads();
-    dsp_i2s_task_deinit();
-    vTaskDelete( t_http_get_task );
+  esp_ota_handle_t ota_handle;
 
+  do {
+    recv_len = recv(connect_socket, ota_buff, OTA_BUFF_SIZE, 0);
 
-    int recv_len;
-    char ota_buff[OTA_BUFF_SIZE] = {0};
-    bool is_req_body_started = false;
-    int content_length = -1;
-    int content_received = 0;
+    if (recv_len > 0) {
+      if (!is_req_body_started) {
+        const char *content_length_start = "Content-Length: ";
+        char *content_length_start_p = strstr(ota_buff, content_length_start) +
+                                       strlen(content_length_start);
+        sscanf(content_length_start_p, "%d", &content_length);
+        ESP_LOGI(TAG, "Detected content length: %d", content_length);
+        ESP_ERROR_CHECK(
+            esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &ota_handle));
+        const char *header_end = "\r\n\r\n";
+        char *body_start_p = strstr(ota_buff, header_end) + strlen(header_end);
+        int body_part_len = recv_len - (body_start_p - ota_buff);
+        esp_ota_write(ota_handle, body_start_p, body_part_len);
+        content_received += body_part_len;
+        is_req_body_started = true;
+      } else {
+        esp_ota_write(ota_handle, ota_buff, recv_len);
+        content_received += recv_len;
 
-    esp_ota_handle_t ota_handle;
-
-    do {
-        recv_len = recv(connect_socket, ota_buff, OTA_BUFF_SIZE, 0);
-
-        if (recv_len > 0)
-        {
-            if (!is_req_body_started)
-            {
-                const char *content_length_start = "Content-Length: ";
-                char *content_length_start_p = strstr(ota_buff, content_length_start) + strlen(content_length_start);
-                sscanf(content_length_start_p, "%d", &content_length);
-                ESP_LOGI(TAG, "Detected content length: %d", content_length);
-                ESP_ERROR_CHECK( esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &ota_handle) );
-                const char *header_end = "\r\n\r\n";
-                char *body_start_p = strstr(ota_buff, header_end) + strlen(header_end);
-                int body_part_len = recv_len - (body_start_p - ota_buff);
-                esp_ota_write(ota_handle, body_start_p, body_part_len);
-                content_received += body_part_len;
-                is_req_body_started = true;
-            }
-	        else
-	        {
-                esp_ota_write(ota_handle, ota_buff, recv_len);
-                content_received += recv_len;
-
-		        percent_loaded = (((float)content_received / (float)content_length) * 100.00);
-		        if ((percent_loaded % 10 == 0) & (percent_loaded != old_percent_loaded)) {
-                    old_percent_loaded = percent_loaded;
-                    ESP_LOGI(TAG, "Uploaded %03u%%", percent_loaded);
-                }
-
-            }
+        percent_loaded =
+            (((float)content_received / (float)content_length) * 100.00);
+        if ((percent_loaded % 10 == 0) &
+            (percent_loaded != old_percent_loaded)) {
+          old_percent_loaded = percent_loaded;
+          ESP_LOGI(TAG, "Uploaded %03u%%", percent_loaded);
         }
-        else if (recv_len < 0)
-        {
-	        ESP_LOGI(TAG, "Error: recv data error! errno=%d", errno);
-        }
+      }
+    } else if (recv_len < 0) {
+      ESP_LOGI(TAG, "Error: recv data error! errno=%d", errno);
+    }
 
-    } while (recv_len > 0 && content_received < content_length);
+  } while (recv_len > 0 && content_received < content_length);
 
-	ESP_LOGI(TAG, "OTA Transferred Finished: %d bytes", content_received);
+  ESP_LOGI(TAG, "OTA Transferred Finished: %d bytes", content_received);
 
-	char res_buff[128];
-	int send_len;
-	send_len = sprintf(res_buff, "200 OK\n\n");
-	send(connect_socket, res_buff, send_len, 0);
-	vTaskDelay(2000 / portTICK_PERIOD_MS);
-	close(connect_socket);
+  char res_buff[128];
+  int send_len;
+  send_len = sprintf(res_buff, "200 OK\n\n");
+  send(connect_socket, res_buff, send_len, 0);
+  vTaskDelay(2000 / portTICK_PERIOD_MS);
+  close(connect_socket);
 
-    ESP_ERROR_CHECK( esp_ota_end(ota_handle) );
+  ESP_ERROR_CHECK(esp_ota_end(ota_handle));
 
-    esp_err_t err = esp_ota_set_boot_partition(update_partition);
+  esp_err_t err = esp_ota_set_boot_partition(update_partition);
 
-	if (err == ESP_OK)
-	{
-		const esp_partition_t *boot_partition = esp_ota_get_boot_partition();
+  if (err == ESP_OK) {
+    const esp_partition_t *boot_partition = esp_ota_get_boot_partition();
 
-		ESP_LOGI(TAG, "***********************************************************");
-		ESP_LOGI(TAG, "OTA Successful");
-		ESP_LOGI(TAG, "Next Boot Partition Subtype %d At Offset 0x%x", boot_partition->subtype, boot_partition->address);
-		ESP_LOGI(TAG, "***********************************************************");
-	}
-	else
-	{
-		ESP_LOGI(TAG, "!!! OTA Failed !!!");
-	}
+    ESP_LOGI(TAG,
+             "***********************************************************");
+    ESP_LOGI(TAG, "OTA Successful");
+    ESP_LOGI(TAG, "Next Boot Partition Subtype %d At Offset 0x%x",
+             boot_partition->subtype, boot_partition->address);
+    ESP_LOGI(TAG,
+             "***********************************************************");
+  } else {
+    ESP_LOGI(TAG, "!!! OTA Failed !!!");
+  }
 
+  // for (int x = 2; x >= 1; x--)
+  //{
+  ESP_LOGI(TAG, "Prepare to restart system..");
+  vTaskDelay(1000 / portTICK_PERIOD_MS);
+  //}
 
-	//for (int x = 2; x >= 1; x--)
-	//{
-	  ESP_LOGI(TAG, "Prepare to restart system..");
-	  vTaskDelay(1000 / portTICK_PERIOD_MS);
-	//}
-
-    esp_restart();
+  esp_restart();
 }

--- a/components/rtprx/CMakeLists.txt
+++ b/components/rtprx/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "rtprx.c" 
+idf_component_register(SRCS "rtprx.c"
                        INCLUDE_DIRS "include"
                        REQUIRES opus)

--- a/components/rtprx/component.mk
+++ b/components/rtprx/component.mk
@@ -1,12 +1,11 @@
 #
 # Main Makefile. This is basically the same as a component makefile.
 #
-# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default, 
-# this will take the sources in the src/ directory, compile them and link them into 
+# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default,
+# this will take the sources in the src/ directory, compile them and link them into
 # lib(subdirectory_name).a in the build directory. This behaviour is entirely configurable,
 # please read the ESP-IDF documents if you need to do this.
 #
 
 COMPONENT_SRCDIRS := .
 # CFLAGS +=
-

--- a/components/rtprx/rtprx.c
+++ b/components/rtprx/rtprx.c
@@ -4,133 +4,144 @@
  * \date    19.10.2019
  * \version   0.1
  *
- * \brief RTP audio stream reciever
+ * \brief RTP audio stream receiver
  *
- * \warning This software is a PROTOTYPE version and is not designed or intended for use in production, especially not for safety-critical applications!
- * The user represents and warrants that it will NOT use or redistribute the Software for such purposes.
- * This prototype is for research purposes only. This software is provided "AS IS," without a warranty of any kind.
+ * \warning This software is a PROTOTYPE version and is not designed or intended
+ * for use in production, especially not for safety-critical applications! The
+ * user represents and warrants that it will NOT use or redistribute the
+ * Software for such purposes. This prototype is for research purposes only.
+ * This software is provided "AS IS," without a warranty of any kind.
  */
 #include "rtprx.h"
 
-#include "freertos/FreeRTOS.h"
-#include "esp_log.h"
-#include "esp_wifi.h"
-#include "esp_netif.h"
+#include <lwip/netdb.h>
 
+#include "driver/i2s.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
 #include "lwip/api.h"
 #include "lwip/err.h"
 #include "lwip/sockets.h"
 #include "lwip/sys.h"
-#include <lwip/netdb.h>
-
-#include "driver/i2s.h"
 #include "opus.h"
 
-//extern uint32_t sample_rate = 48000;   xxx fixme
+// extern uint32_t sample_rate = 48000;   xxx fixme
 
 static bool rtpRxState = 0;
 
 void rtp_rx_start() {
-  if (rtpRxState == 0 )
-  { setup_rtp_i2s();
-    xTaskCreate(rtp_rx_task, "RTPRx", 12*1024, NULL, 0, NULL);
+  if (rtpRxState == 0) {
+    setup_rtp_i2s();
+    xTaskCreate(rtp_rx_task, "RTPRx", 12 * 1024, NULL, 0, NULL);
     rtpRxState = 1;
   }
 }
 
 void rtp_rx_stop() {
-  if (rtpRxState == 1)
-  { i2s_driver_uninstall(0);
-    //vTaskDelete(xTaskSignal);    xxx Fix me
+  if (rtpRxState == 1) {
+    i2s_driver_uninstall(0);
+    // vTaskDelete(xTaskSignal);    xxx Fix me
     rtpRxState = 0;
   }
 }
 
-
-void rtp_rx_task(void *pvParameters){
+void rtp_rx_task(void *pvParameters) {
   OpusDecoder *decoder;
 
-  //int size = opus_decoder_get_size(2);
+  // int size = opus_decoder_get_size(2);
   int oe = 0;
-  decoder = opus_decoder_create(48000,2,&oe);
+  decoder = opus_decoder_create(48000, 2, &oe);
   //  int error = opus_decoder_init(decoder, 48000, 2);
- 	printf("Initialized Decoder: %d", oe);
+  printf("Initialized Decoder: %d", oe);
 
-  //int32_t *audio32 = (int32_t*)malloc(960*sizeof(int32_t));
-	int16_t *audio = (int16_t *)malloc(960*2*sizeof(int16_t));
+  // int32_t *audio32 = (int32_t*)malloc(960*sizeof(int32_t));
+  int16_t *audio = (int16_t *)malloc(960 * 2 * sizeof(int16_t));
   i2s_zero_dma_buffer(0);
   static struct netconn *conn;
   static struct netbuf *buf;
-  static uint32_t pkg = 0 ;
+  static uint32_t pkg = 0;
   static uint32_t pkgerror = 0;
   err_t err;
   uint16_t oldseq = 1;
   uint16_t first = 1;
   conn = netconn_new(NETCONN_UDP);
-  if (conn!=NULL)
-  { printf("Net RTP RX\n");
+  if (conn != NULL) {
+    printf("Net RTP RX\n");
     netconn_bind(conn, IP_ADDR_ANY, 1350);
     netconn_listen(conn);
     printf("Net RTP will enter loopn\n");
     while (1) {
-      netconn_recv(conn,&buf);
-      if (buf == NULL)
-      { printf("NETCONN RX error \n"); }
+      netconn_recv(conn, &buf);
+      if (buf == NULL) {
+        printf("NETCONN RX error \n");
+      }
       pkg++;
 
       uint8_t *p = (buf->p->payload);
-      uint16_t seq =  (p[2]<<8)+p[3];
-      if ( (seq!=oldseq+1) & (first != 1) )
-      { printf("seq : %d, oldseq : %d \n",seq,oldseq);
-        uint16_t errors = seq-oldseq-1;
+      uint16_t seq = (p[2] << 8) + p[3];
+      if ((seq != oldseq + 1) & (first != 1)) {
+        printf("seq : %d, oldseq : %d \n", seq, oldseq);
+        uint16_t errors = seq - oldseq - 1;
         pkgerror = pkgerror + errors;
-        printf("ERROR --- Package drop : %d  %d \n",errors, pkgerror);
+        printf("ERROR --- Package drop : %d  %d \n", errors, pkgerror);
         size_t bWritten;
-        //for (int i = 0; i;i++ )
-        int ret = i2s_write_expand(0, (char*)audio, 960*2*sizeof(int16_t),16,32, &bWritten, 100);
-        printf("bWritten : %d  ret : %d \n ",bWritten,ret);
+        // for (int i = 0; i;i++ )
+        int ret = i2s_write_expand(0, (char *)audio, 960 * 2 * sizeof(int16_t),
+                                   16, 32, &bWritten, 100);
+        printf("bWritten : %d  ret : %d \n ", bWritten, ret);
 
-        //opus_pkg = NULL;
+        // opus_pkg = NULL;
       }
 
-      if (seq<oldseq)
-      { printf("ERROR --- Packege order:"); }
+      if (seq < oldseq) {
+        printf("ERROR --- Package order:");
+      }
       oldseq = seq;
       first = 0;
-      //printf("UDP package len : %d ->  \n", buf->p->len);
-      //printf("UDP package     : %02x %02x %02x %02x\n",p[0],p[1],p[2],p[3]);
-      //printf("Timestamp       : %02x %02x %02x %02x\n",p[4],p[5],p[6],p[7]);
-      //printf("Sync source     : %02x %02x %02x %02x\n",p[8],p[9],p[10],p[11]);
-      //printf("R1              : %d \n",(p[12]&0xf8)>>3) ;
-      //int size = 240;
+      // printf("UDP package len : %d ->  \n", buf->p->len);
+      // printf("UDP package     : %02x %02x %02x %02x\n",p[0],p[1],p[2],p[3]);
+      // printf("Timestamp       : %02x %02x %02x %02x\n",p[4],p[5],p[6],p[7]);
+      // printf("Sync source     : %02x %02x %02x
+      // %02x\n",p[8],p[9],p[10],p[11]); printf("R1              : %d
+      // \n",(p[12]&0xf8)>>3) ; int size = 240;
       unsigned char *opus_pkg = buf->p->payload + 12;
-      int size = opus_decode(decoder, (unsigned char *)opus_pkg, buf->p->len-12, (opus_int16*)audio, 960, 0);
-      if (size < 0 )
-      { printf("Decode error : %d \n",size); }
+      int size = opus_decode(decoder, (unsigned char *)opus_pkg,
+                             buf->p->len - 12, (opus_int16 *)audio, 960, 0);
+      if (size < 0) {
+        printf("Decode error : %d \n", size);
+      }
 
-      //for (int i = 0; i < size*2; i++) {
+      // for (int i = 0; i < size*2; i++) {
       //  audio[i*2]   = 0x0000;
       //  audio[i*2+1] = 0x0000;
       //}
 
       size_t bWritten;
-      int ret = i2s_write_expand(0, (char*)audio, size*2*sizeof(int16_t),16,32, &bWritten, 100);
-      if (ret != 0 ) printf("Error I2S written: %d %d %d \n",ret, size*2*sizeof(int16_t) ,bWritten);
+      int ret = i2s_write_expand(0, (char *)audio, size * 2 * sizeof(int16_t),
+                                 16, 32, &bWritten, 100);
+      if (ret != 0)
+        printf("Error I2S written: %d %d %d \n", ret,
+               size * 2 * sizeof(int16_t), bWritten);
 
-      if ((pkg%1000)==1) {
-        //printf("I2S written: %d %d \n", size*sizeof(int32_t) ,bWritten);
-        printf("%d > %d %d %d\n",pkg, size,  buf->p->len, buf->p->tot_len );
+      if ((pkg % 1000) == 1) {
+        // printf("I2S written: %d %d \n", size*sizeof(int32_t) ,bWritten);
+        printf("%d > %d %d %d\n", pkg, size, buf->p->len, buf->p->tot_len);
         printf("UDP package len : %d ->  \n", buf->p->len);
-        printf("UDP package     : %02x %02x %02x %02x\n",p[0],p[1],p[2],p[3]);
-        printf("Timestamp       : %02x %02x %02x %02x\n",p[4],p[5],p[6],p[7]);
-        printf("Sync source     : %02x %02x %02x %02x\n",p[8],p[9],p[10],p[11]);
-        printf("R1              : %d \n",(p[12]&0xf8)>>3) ;
+        printf("UDP package     : %02x %02x %02x %02x\n", p[0], p[1], p[2],
+               p[3]);
+        printf("Timestamp       : %02x %02x %02x %02x\n", p[4], p[5], p[6],
+               p[7]);
+        printf("Sync source     : %02x %02x %02x %02x\n", p[8], p[9], p[10],
+               p[11]);
+        printf("R1              : %d \n", (p[12] & 0xf8) >> 3);
 
-        for (int i=0;i<8;i++)
-          printf("%02d %04x %04x\n",i,audio[2*i],audio[2*i+1]);
+        for (int i = 0; i < 8; i++)
+          printf("%02d %04x %04x\n", i, audio[2 * i], audio[2 * i + 1]);
       }
 
-      //netbuf_free(buf);
+      // netbuf_free(buf);
       netbuf_delete(buf);
     }
   }
@@ -138,30 +149,29 @@ void rtp_rx_task(void *pvParameters){
   netconn_delete(conn);
 }
 
-void setup_rtp_i2s()
-{
+void setup_rtp_i2s() {
   i2s_config_t i2s_config = {
-    .mode = I2S_MODE_MASTER | I2S_MODE_TX,                                  // Only TX
-    .sample_rate = 48000,
-    .bits_per_sample = 32,
-    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,                           //2-channels
-    .communication_format = I2S_COMM_FORMAT_I2S,
-    .dma_buf_count = 8,
-    .dma_buf_len = 480,
-    //.intr_alloc_flags = 1,                                                  //Default interrupt priority
-    .use_apll = true,
-    .fixed_mclk = 0,
-    .tx_desc_auto_clear = true                                                //Auto clear tx descriptor on underflow
+      .mode = I2S_MODE_MASTER | I2S_MODE_TX,  // Only TX
+      .sample_rate = 48000,
+      .bits_per_sample = 32,
+      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,  // 2-channels
+      .communication_format = I2S_COMM_FORMAT_I2S,
+      .dma_buf_count = 8,
+      .dma_buf_len = 480,
+      //.intr_alloc_flags = 1, //Default interrupt priority
+      .use_apll = true,
+      .fixed_mclk = 0,
+      .tx_desc_auto_clear = true  // Auto clear tx descriptor on underflow
   };
 
   i2s_driver_install(0, &i2s_config, 0, NULL);
   i2s_zero_dma_buffer(0);
 
   i2s_pin_config_t pin_config = {
-    .bck_io_num   = 12, //CONFIG_EXAMPLE_I2S_BCK_PIN,
-    .ws_io_num    = 13, //CONFIG_EXAMPLE_I2S_LRCK_PIN,
-    .data_out_num = 14, //CONFIG_EXAMPLE_I2S_DATA_PIN,
-    .data_in_num = -1                                                       //Not used
+      .bck_io_num = 12,    // CONFIG_EXAMPLE_I2S_BCK_PIN,
+      .ws_io_num = 13,     // CONFIG_EXAMPLE_I2S_LRCK_PIN,
+      .data_out_num = 14,  // CONFIG_EXAMPLE_I2S_DATA_PIN,
+      .data_in_num = -1    // Not used
   };
 
   i2s_set_pin(0, &pin_config);

--- a/components/wifi_interface/CMakeLists.txt
+++ b/components/wifi_interface/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "wifi_interface.c" 
+idf_component_register(SRCS "wifi_interface.c"
                        INCLUDE_DIRS "include")

--- a/components/wifi_interface/include/wifi_interface.h
+++ b/components/wifi_interface/include/wifi_interface.h
@@ -8,19 +8,20 @@ EventGroupHandle_t s_wifi_event_group;
 /* Hardcoded WiFi configuration that you can set via
    'make menuconfig'.
 */
-#define WIFI_SSID          CONFIG_WIFI_SSID
-#define WIFI_PASSWORD      CONFIG_WIFI_PASSWORD
+#define WIFI_SSID CONFIG_WIFI_SSID
+#define WIFI_PASSWORD CONFIG_WIFI_PASSWORD
 #define WIFI_MAXIMUM_RETRY CONFIG_WIFI_MAXIMUM_RETRY
 
-/* The event group allows multiple bits for each event, but we only care about two events:
+/* The event group allows multiple bits for each event, but we only care about
+ * two events:
  * - we are connected to the AP with an IP
  * - we failed to connect after the maximum amount of retries */
 #define WIFI_CONNECTED_BIT BIT0
-#define WIFI_FAIL_BIT      BIT1
+#define WIFI_FAIL_BIT BIT1
 
-void event_handler(void* arg, esp_event_base_t event_base,
-                                int32_t event_id, void* event_data);
+void event_handler(void* arg, esp_event_base_t event_base, int32_t event_id,
+                   void* event_data);
 
 void wifi_init_sta(void);
 
-#endif  /* _WIFI_INTERFACE_H_ */
+#endif /* _WIFI_INTERFACE_H_ */

--- a/components/wifi_interface/wifi_interface.c
+++ b/components/wifi_interface/wifi_interface.c
@@ -5,108 +5,107 @@
     Must be taken over/merge with wifi provision
 */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/event_groups.h"
-#include "esp_wifi.h"
-#include "esp_event.h"
-#include "esp_log.h"
 #include "wifi_interface.h"
 
-static const char *TAG = "WIFI";
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+
+static const char* TAG = "WIFI";
 
 char mac_address[18];
 
 static int s_retry_num = 0;
 
-/* FreeRTOS event group to signal when we are connected & ready to make a request */
-//static EventGroupHandle_t wifi_event_group;
+/* FreeRTOS event group to signal when we are connected & ready to make a
+ * request */
+// static EventGroupHandle_t wifi_event_group;
 
 /* The event group allows multiple bits for each event,
    but we only care about one event - are we connected
    to the AP with an IP? */
 
-void event_handler(void* arg, esp_event_base_t event_base,
-                                int32_t event_id, void* event_data)
-{
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
-        esp_wifi_connect();
-    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-		if (s_retry_num < WIFI_MAXIMUM_RETRY) {
-            esp_wifi_connect();
-            s_retry_num++;
-            ESP_LOGI(TAG, "retry to connect to the AP");
-        } else {
-            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
-        }
-        ESP_LOGI(TAG,"connect to the AP fail");
-    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-        ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
-        ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
-        s_retry_num = 0;
-        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+void event_handler(void* arg, esp_event_base_t event_base, int32_t event_id,
+                   void* event_data) {
+  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+    esp_wifi_connect();
+  } else if (event_base == WIFI_EVENT &&
+             event_id == WIFI_EVENT_STA_DISCONNECTED) {
+    if (s_retry_num < WIFI_MAXIMUM_RETRY) {
+      esp_wifi_connect();
+      s_retry_num++;
+      ESP_LOGI(TAG, "retry to connect to the AP");
+    } else {
+      xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
     }
+    ESP_LOGI(TAG, "connect to the AP fail");
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+    ip_event_got_ip_t* event = (ip_event_got_ip_t*)event_data;
+    ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
+    s_retry_num = 0;
+    xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+  }
 }
 
-void wifi_init_sta(void)
-{
-    s_wifi_event_group = xEventGroupCreate();
+void wifi_init_sta(void) {
+  s_wifi_event_group = xEventGroupCreate();
 
-    ESP_ERROR_CHECK(esp_netif_init());
+  ESP_ERROR_CHECK(esp_netif_init());
 
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-    esp_netif_create_default_wifi_sta();
+  ESP_ERROR_CHECK(esp_event_loop_create_default());
+  esp_netif_create_default_wifi_sta();
 
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+  wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+  ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
-    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                             &event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                             &event_handler, NULL));
 
-    wifi_config_t wifi_config = {
-        .sta = {
-			.ssid = WIFI_SSID,
-            .password = WIFI_PASSWORD,
-			.threshold.authmode = WIFI_AUTH_WPA2_PSK,
-            .pmf_cfg = {
-                .capable = true,
-                .required = false
-            },
-        },
-    };
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
-    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config) );
-    ESP_ERROR_CHECK(esp_wifi_start() );
+  wifi_config_t wifi_config = {
+      .sta =
+          {
+              .ssid = WIFI_SSID,
+              .password = WIFI_PASSWORD,
+              .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+              .pmf_cfg = {.capable = true, .required = false},
+          },
+  };
+  ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+  ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+  ESP_ERROR_CHECK(esp_wifi_start());
 
-    ESP_LOGI(TAG, "wifi_init_sta finished.");
+  ESP_LOGI(TAG, "wifi_init_sta finished.");
 
-    /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
-     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
-    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
-            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-            pdFALSE,
-            pdFALSE,
-            portMAX_DELAY);
+  /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or
+   * connection failed for the maximum number of re-tries (WIFI_FAIL_BIT). The
+   * bits are set by event_handler() (see above) */
+  EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+                                         WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                         pdFALSE, pdFALSE, portMAX_DELAY);
 
-    /* xEventGroupWaitBits() returns the bits before the call returned, hence we can test which event actually
-     * happened. */
-    if (bits & WIFI_CONNECTED_BIT) {
-        ESP_LOGI(TAG, "connected to ap SSID:%s",
-                 WIFI_SSID);
-    } else if (bits & WIFI_FAIL_BIT) {
-        ESP_LOGI(TAG, "Failed to connect to SSID:%s, password:%s",
-                 WIFI_SSID, WIFI_PASSWORD);
-    } else {
-        ESP_LOGE(TAG, "UNEXPECTED EVENT");
-    }
+  /* xEventGroupWaitBits() returns the bits before the call returned, hence we
+   * can test which event actually happened. */
+  if (bits & WIFI_CONNECTED_BIT) {
+    ESP_LOGI(TAG, "connected to ap SSID:%s", WIFI_SSID);
+  } else if (bits & WIFI_FAIL_BIT) {
+    ESP_LOGI(TAG, "Failed to connect to SSID:%s, password:%s", WIFI_SSID,
+             WIFI_PASSWORD);
+  } else {
+    ESP_LOGE(TAG, "UNEXPECTED EVENT");
+  }
 
-    uint8_t base_mac[6];
-    // Get MAC address for WiFi station
-    esp_read_mac(base_mac, ESP_MAC_WIFI_STA);
-    sprintf(mac_address, "%02X:%02X:%02X:%02X:%02X:%02X", base_mac[0], base_mac[1], base_mac[2], base_mac[3], base_mac[4], base_mac[5]);
+  uint8_t base_mac[6];
+  // Get MAC address for WiFi station
+  esp_read_mac(base_mac, ESP_MAC_WIFI_STA);
+  sprintf(mac_address, "%02X:%02X:%02X:%02X:%02X:%02X", base_mac[0],
+          base_mac[1], base_mac[2], base_mac[3], base_mac[4], base_mac[5]);
 
-
-    //ESP_ERROR_CHECK(esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler));
-    //ESP_ERROR_CHECK(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler));
-    //vEventGroupDelete(s_wifi_event_group);
+  // ESP_ERROR_CHECK(esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP,
+  // &event_handler)); ESP_ERROR_CHECK(esp_event_handler_unregister(WIFI_EVENT,
+  // ESP_EVENT_ANY_ID, &event_handler)); vEventGroupDelete(s_wifi_event_group);
 }

--- a/main/main.c
+++ b/main/main.c
@@ -6,57 +6,55 @@
 */
 
 #include <string.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/event_groups.h"
-#include "esp_system.h"
 
-#include "wifi_interface.h"
-#include "esp_wifi.h"
 #include "esp_event.h"
 #include "esp_log.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
 #include "nvs_flash.h"
+#include "wifi_interface.h"
 
 // Minimum ESP-IDF stuff only hardware abstraction stuff
 #include "board.h"
 #include "es8388.h"
-
+#include "esp_netif.h"
+#include "lwip/dns.h"
 #include "lwip/err.h"
+#include "lwip/netdb.h"
 #include "lwip/sockets.h"
 #include "lwip/sys.h"
-#include "lwip/netdb.h"
-#include "lwip/dns.h"
-#include "esp_netif.h"
-#include "net_functions.h"
 #include "mdns.h"
+#include "net_functions.h"
 
 // Opus decoder is implemented as a subcomponet from master git repo
-#include "opus.h"
+#include <sys/time.h>
 
 #include "driver/i2s.h"
 #include "dsp_processor.h"
-#include "snapcast.h"
-
-#include <sys/time.h>
-
+#include "opus.h"
 #include "ota_server.h"
+#include "snapcast.h"
 
 xTaskHandle t_http_get_task;
 xQueueHandle flow_queue;
 xQueueHandle i2s_queue;
 uint32_t buffer_ms = 400;
-uint8_t  muteCH[4] = {0};
+uint8_t muteCH[4] = {0};
 struct timeval tdif;
 audio_board_handle_t board_handle = NULL;
 
-int timeval_subtract(struct timeval *result, struct timeval *x, struct timeval *y);
+int timeval_subtract(struct timeval *result, struct timeval *x,
+                     struct timeval *y);
 
 /* snapast parameters; configurable in menuconfig */
-#define SNAPCAST_SERVER_USE_MDNS  CONFIG_SNAPSERVER_USE_MDNS
-#define SNAPCAST_SERVER_HOST      CONFIG_SNAPSERVER_HOST
-#define SNAPCAST_SERVER_PORT      CONFIG_SNAPSERVER_PORT
-#define SNAPCAST_BUFF_LEN         CONFIG_SNAPCLIENT_BUFF_LEN
-#define SNAPCAST_CLIENT_NAME      CONFIG_SNAPCLIENT_NAME
+#define SNAPCAST_SERVER_USE_MDNS CONFIG_SNAPSERVER_USE_MDNS
+#define SNAPCAST_SERVER_HOST CONFIG_SNAPSERVER_HOST
+#define SNAPCAST_SERVER_PORT CONFIG_SNAPSERVER_PORT
+#define SNAPCAST_BUFF_LEN CONFIG_SNAPCLIENT_BUFF_LEN
+#define SNAPCAST_CLIENT_NAME CONFIG_SNAPCLIENT_NAME
 
 unsigned int addr;
 uint32_t port = SNAPCAST_SERVER_PORT;
@@ -67,475 +65,504 @@ static char buff[SNAPCAST_BUFF_LEN];
 
 extern char mac_address[18];
 extern EventGroupHandle_t s_wifi_event_group;
-enum codec_type { PCM , FLAC, OGG, OPUS };
+enum codec_type { PCM, FLAC, OGG, OPUS };
 
-static void http_get_task(void *pvParameters)
-{
-    struct sockaddr_in servaddr;
-    char *start;
-    int sockfd;
+static void http_get_task(void *pvParameters) {
+  struct sockaddr_in servaddr;
+  char *start;
+  int sockfd;
 
-    char base_message_serialized[BASE_MESSAGE_SIZE];
-    char *hello_message_serialized;
-    int result, size, id_counter;
+  char base_message_serialized[BASE_MESSAGE_SIZE];
+  char *hello_message_serialized;
+  int result, size, id_counter;
 
-    uint32_t client_state_muted = 0;
-    struct timeval now, ttx, trx, tv1,  last_time_sync;
+  uint32_t client_state_muted = 0;
+  struct timeval now, ttx, trx, tv1, last_time_sync;
 
-    uint8_t * timestampSize;
-    timestampSize = malloc(12);
+  uint8_t timestampSize[12];
 
-    time_message_t time_message;
-    double time_diff;
+  time_message_t time_message;
+  double time_diff;
 
-    last_time_sync.tv_sec = 0;
-    last_time_sync.tv_usec = 0;
-    id_counter = 0;
+  last_time_sync.tv_sec = 0;
+  last_time_sync.tv_usec = 0;
+  id_counter = 0;
 
-    int codec = 0;
+  int codec = 0;
 
-    OpusDecoder *decoder = NULL;
+  OpusDecoder *decoder = NULL;
 
-	int16_t *audio = (int16_t *)malloc(960*2*sizeof(int16_t)); // 960*2: 20ms, 960*1: 10ms
-    //uint8_t *timestampSize = malloc(3*sizeof(uint32_t));
-    int16_t pcm_size = 120;
-    uint16_t channels;
-    uint32_t cnt = 0;
-    int chunk_res;
-    dsp_i2s_task_init(48000,false);
+  int16_t *audio =
+      (int16_t *)malloc(960 * 2 * sizeof(int16_t));  // 960*2: 20ms, 960*1: 10ms
 
-    while(1) {
-        /* Wait for the callback to set the CONNECTED_BIT in the
-           event group.
-        */
+  int16_t pcm_size = 120;
+  uint16_t channels;
+  uint32_t cnt = 0;
+  int chunk_res;
+  dsp_i2s_task_init(48000, false);
 
-        xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT,
-                            false, true, portMAX_DELAY);
+  while (1) {
+    /* Wait for the callback to set the CONNECTED_BIT in the
+       event group.
+    */
 
-		// configure a failsafe snapserver according to CONFIG values
-		servaddr.sin_family = AF_INET;
-		inet_pton(AF_INET, CONFIG_SNAPSERVER_HOST, &(servaddr.sin_addr.s_addr));
-        servaddr.sin_port = htons(CONFIG_SNAPSERVER_PORT);
+    xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, false, true,
+                        portMAX_DELAY);
+
+    // configure a failsafe snapserver according to CONFIG values
+    servaddr.sin_family = AF_INET;
+    inet_pton(AF_INET, CONFIG_SNAPSERVER_HOST, &(servaddr.sin_addr.s_addr));
+    servaddr.sin_port = htons(CONFIG_SNAPSERVER_PORT);
 
 #ifdef CONFIG_SNAPCLIENT_USE_MDNS
-        // Find snapcast server using mDNS
-        // Connect to first snapcast server found
-        ESP_LOGI(TAG, "Enable mdns") ;
-        mdns_init();
-        mdns_result_t * r = NULL;
-        esp_err_t err = 0;
-        while ( !r || err )
-        {  ESP_LOGI(TAG, "Lookup snapcast service on network");
-           esp_err_t err = mdns_query_ptr("_snapcast", "_tcp", 3000, 20,  &r);
-           if(err){
-             ESP_LOGE(TAG, "Query Failed");
-           }
-           if(!r){
-             ESP_LOGW(TAG, "No results found!");
-			 break;
-           }
-		   // mdns config failed, wait 1s and try again
-           vTaskDelay(1000/portTICK_PERIOD_MS);
-        }
-		char ip4[INET_ADDRSTRLEN];
-		inet_ntop(AF_INET, &(r->addr->addr.u_addr.ip4.addr), ip4, INET_ADDRSTRLEN);
+    // Find snapcast server using mDNS
+    // Connect to first snapcast server found
+    ESP_LOGI(TAG, "Enable mdns");
+    mdns_init();
+    mdns_result_t *r = NULL;
+    esp_err_t err = 0;
+    while (!r || err) {
+      ESP_LOGI(TAG, "Lookup snapcast service on network");
+      esp_err_t err = mdns_query_ptr("_snapcast", "_tcp", 3000, 20, &r);
+      if (err) {
+        ESP_LOGE(TAG, "Query Failed");
+      }
+      if (!r) {
+        ESP_LOGW(TAG, "No results found!");
+        break;
+      }
+      // mdns config failed, wait 1s and try again
+      vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+    char ip4[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &(r->addr->addr.u_addr.ip4.addr), ip4, INET_ADDRSTRLEN);
 
-        ESP_LOGI(TAG,"Found Snapcast server: %s:%d", ip4, r->port);
-        servaddr.sin_addr.s_addr = r->addr->addr.u_addr.ip4.addr;
-        servaddr.sin_port = htons(r->port);
-        mdns_query_results_free(r);
+    ESP_LOGI(TAG, "Found Snapcast server: %s:%d", ip4, r->port);
+    servaddr.sin_addr.s_addr = r->addr->addr.u_addr.ip4.addr;
+    servaddr.sin_port = htons(r->port);
+    mdns_query_results_free(r);
 #endif
 
-		// servaddr is configured, now open a connection
-        sockfd = socket(AF_INET, SOCK_STREAM, 0);
-        if(sockfd < 0) {
-            ESP_LOGE(TAG, "... Failed to allocate socket.");
-            vTaskDelay(1000 / portTICK_PERIOD_MS);
-            continue;
-        }
-        ESP_LOGI(TAG, "... allocated socket");
-
-        if (connect(sockfd, (struct sockaddr*)&servaddr, sizeof(servaddr)) != 0) {
-            ESP_LOGE(TAG, "... socket connect failed errno=%d", errno);
-            close(sockfd);
-            vTaskDelay(4000 / portTICK_PERIOD_MS);
-            continue;
-        }
-
-        ESP_LOGI(TAG, "... connected");
-
-        codec_header_message_t codec_header_message;
-        wire_chunk_message_t wire_chunk_message;
-        server_settings_message_t server_settings_message;
-
-        result = gettimeofday(&now, NULL);
-        if (result) {
-            ESP_LOGI(TAG, "Failed to gettimeofday\r\n");
-            return;
-        }
-
-        bool received_header = false;
-        base_message_t base_message = {
-            SNAPCAST_MESSAGE_HELLO,      // type
-            0x0,                         // id
-            0x0,                         // refersTo
-            { now.tv_sec, now.tv_usec }, // sent
-            { 0x0, 0x0 },                // received
-            0x0,                         // size
-        };
-
-        hello_message_t hello_message = {
-            mac_address,
-            SNAPCAST_CLIENT_NAME,  // hostname
-            "0.0.2",               // client version
-            "libsnapcast",         // client name
-            "esp32",               // os name
-            "xtensa",              // arch
-            1,                     // instance
-            mac_address,           // id
-            2,                     // protocol version
-        };
-
-        hello_message_serialized = hello_message_serialize(&hello_message, (size_t*) &(base_message.size));
-        if (!hello_message_serialized) {
-            ESP_LOGI(TAG, "Failed to serialize hello message\r\b");
-            return;
-        }
-
-        result = base_message_serialize(
-            &base_message,
-            base_message_serialized,
-            BASE_MESSAGE_SIZE
-        );
-        if (result) {
-            ESP_LOGI(TAG, "Failed to serialize base message\r\n");
-            return;
-        }
-
-        write(sockfd, base_message_serialized, BASE_MESSAGE_SIZE);
-        write(sockfd, hello_message_serialized, base_message.size);
-        free(hello_message_serialized);
-
-        fd_set read_push_set;
-        //struct timeval to;
-        int retval;
-        for (;;) {
-            // Need to have time out if 100 ms between packeage to signal
-            size = 0;                                // Audio flow stopped
-            // Read from socket with time out
-            FD_ZERO (&read_push_set);
-	        FD_SET (sockfd, &read_push_set);
-
-            struct timeval to;
-            to.tv_sec = 0;
-	        to.tv_usec = 300000;
-            // Block until input arrives on one or more active sockets.
-	        retval = select (FD_SETSIZE, &read_push_set, NULL, NULL, &to);
-            if (retval) {
-              while (size < BASE_MESSAGE_SIZE) {
-                result = read(sockfd, &(buff[size]), BASE_MESSAGE_SIZE - size);
-                if (result < 0) {
-                  ESP_LOGI(TAG, "Failed to read from server: %d\r\n", result);
-                  return;
-                }
-                size += result;
-              }
-            }
-            else
-            {
-               ESP_LOGI(TAG, "Socket timeout after %d ms\r\n",(uint32_t)to.tv_usec/1000);
-               client_state_muted = 2;
-               xQueueSend(flow_queue,&client_state_muted, 10);
-               continue;    // Return wait for next socket package
-            }
-
-            result = gettimeofday(&now, NULL);
-            if (result) {
-                ESP_LOGI(TAG, "Failed to gettimeofday\r\n");
-                return;
-            }
-
-            result = base_message_deserialize(&base_message, buff, size);
-            if (result) {
-                ESP_LOGI(TAG, "Failed to read base message: %d\r\n", result);
-                return;
-            }
-            //ESP_LOGI(TAG,"Rx dif : %d %d", base_message.sent.sec, base_message.sent.usec/1000);
-
-            base_message.received.sec =  now.tv_sec;
-            base_message.received.usec = now.tv_usec;
-
-            start = buff;
-            size = 0;
-            while (size < base_message.size) {
-                result = read(sockfd, &(buff[size]), base_message.size - size);
-                if (result < 0) {
-                    ESP_LOGI(TAG, "Failed to read from server: %d\r\n", result);
-                    return;
-                }
-                size += result;
-            }
-
-            switch (base_message.type) {
-                case SNAPCAST_MESSAGE_CODEC_HEADER:
-                    result = codec_header_message_deserialize(&codec_header_message, start, size);
-                    if (result) {
-                        ESP_LOGI(TAG, "Failed to read codec header: %d\r\n", result);
-                        return;
-                    }
-
-                    ESP_LOGI(TAG, "Received codec header message\r\n");
-
-                    size = codec_header_message.size;
-                    start = codec_header_message.payload;
-                    if (strcmp(codec_header_message.codec,"opus") == 0) {
-                       uint32_t rate;
-                       memcpy(&rate, start+4,sizeof(rate));
-                       uint16_t bits;
-                       memcpy(&bits, start+8,sizeof(bits));
-                       memcpy(&channels, start+10,sizeof(channels));
-                       ESP_LOGI(TAG, "Opus sampleformat: %d:%d:%d\n",rate,bits,channels);
-                       int error = 0;
-                       decoder = opus_decoder_create(rate,channels,&error);
-                       if (error != 0)
-                       { ESP_LOGI(TAG, "Failed to init opus coder");
-                         return;
-                       }
-                       codec = OPUS;
-                       ESP_LOGI(TAG, "Initialized opus Decoder: %d", error);
-
-                    } else if (strcmp(codec_header_message.codec,"pcm") == 0) {
-                       codec = PCM;
-
-                    } else
-                    {
-                       ESP_LOGI(TAG, "Codec : %s not supported\n",codec_header_message.codec);
-                       ESP_LOGI(TAG, "Change encoder codec to opus in /etc/snapserver.conf on server\n");
-                       return;
-                    }
-                    ESP_LOGI(TAG, "Codec : %s , Size: %d \n",codec_header_message.codec,size);
-
-                    codec_header_message_free(&codec_header_message);
-                    received_header = true;
-
-                break;
-
-                case SNAPCAST_MESSAGE_WIRE_CHUNK:
-                    cnt++;
-                    if (!received_header) {   // Ignore audio packets until codec configured
-                        continue;
-                    }
-
-                      result = wire_chunk_message_deserialize(&wire_chunk_message, start, size);
-                      if (result) {
-                          ESP_LOGI(TAG, "Failed to read wire chunk: %d\r\n", result);
-                          return;
-                      }
-                      size = wire_chunk_message.size;
-                      start = (wire_chunk_message.payload);
-                      switch (codec) {
-                           case OPUS : {
-                              int frame_size = 0;
-                              while ((frame_size = opus_decode(decoder, (unsigned char *)start, size, (opus_int16*)audio,
-                                                     pcm_size/channels, 0)) == OPUS_BUFFER_TOO_SMALL)
-                              {  pcm_size = pcm_size * 2;
-                                 ESP_LOGI(TAG, "OPUS encoding buffer too small, resizing to %d samples per channel", pcm_size/channels);
-                              }
-                              //ESP_LOGI(TAG, "time stamp in : %d",wire_chunk_message.timestamp.sec);
-                              if (frame_size < 0 )
-                              {
-                                ESP_LOGE(TAG, "Decode error : %d \n",frame_size);
-                              } else
-                              {
-                                //pack(&timestampSize,wire_chunk_message.timestamp,frame_size*2*size(uint16_t))
-                                memcpy(timestampSize, &wire_chunk_message.timestamp.sec, sizeof(wire_chunk_message.timestamp.sec));
-                                memcpy(timestampSize+4, &wire_chunk_message.timestamp.usec, sizeof(wire_chunk_message.timestamp.usec));
-                                uint32_t chunk_size = frame_size*2*sizeof(uint16_t) ;
-                                memcpy(timestampSize+8, &chunk_size, sizeof(chunk_size));
-
-                                //ESP_LOGI(TAG, "Network jitter %d %d",(uint32_t) wire_chunk_message.timestamp.usec/1000,
-                                //                                          (uint32_t) base_message.sent.usec/1000);
-
-                                if ((chunk_res = write_ringbuf(timestampSize,3*sizeof(uint32_t))) != 12) {
-                                  ESP_LOGI(TAG, "Error writing timestamp to ring buffer: %d",chunk_res);
-                                }
-                                if ((chunk_res = write_ringbuf((const uint8_t *)audio,chunk_size)) != chunk_size) {
-                                  ESP_LOGI(TAG, "Error writing data to ring buffer: %d",chunk_res);
-                                }
-                              }
-                              break;
-                            }
-                            case PCM : {
-
-                                memcpy(timestampSize, &wire_chunk_message.timestamp.sec, sizeof(wire_chunk_message.timestamp.sec));
-                                memcpy(timestampSize+4, &wire_chunk_message.timestamp.usec, sizeof(wire_chunk_message.timestamp.usec));
-                                uint32_t chunk_size = size ;
-                                memcpy(timestampSize+8, &chunk_size, sizeof(chunk_size));
-
-                                //ESP_LOGI(TAG, "Network jitter %d %d",(uint32_t) wire_chunk_message.timestamp.usec/1000,
-                                //                                          (uint32_t) base_message.sent.usec/1000);
-
-                                if ((chunk_res = write_ringbuf(timestampSize,3*sizeof(uint32_t))) != 12) {
-                                  ESP_LOGI(TAG, "Error writing timestamp to ring buffer: %d",chunk_res);
-                                }
-
-                                if ((chunk_res = write_ringbuf((const uint8_t *)start,size)) != size) {
-                                  ESP_LOGI(TAG, "Error writing data to ring buffer: %d",chunk_res);
-                                }
-
-                              break;
-                            }
-                         }
-                    wire_chunk_message_free(&wire_chunk_message);
-					break;
-
-                case SNAPCAST_MESSAGE_SERVER_SETTINGS:
-                    // The first 4 bytes in the buffer are the size of the string.
-                    // We don't need this, so we'll shift the entire buffer over 4 bytes
-                    // and use the extra room to add a null character so cJSON can pares it.
-                    memmove(start, start + 4, size - 4);
-                    start[size - 3] = '\0';
-                    result = server_settings_message_deserialize(&server_settings_message, start);
-                    if (result) {
-                        ESP_LOGI(TAG, "Failed to read server settings: %d\r\n", result);
-                        return;
-                    }
-                    // log mute state, buffer, latency
-                    buffer_ms = server_settings_message.buffer_ms;
-                    ESP_LOGI(TAG, "Buffer length:  %d", server_settings_message.buffer_ms);
-                    ESP_LOGI(TAG, "Ringbuffer size:%d", server_settings_message.buffer_ms*48*4);
-                    ESP_LOGI(TAG, "Latency:        %d", server_settings_message.latency);
-                    ESP_LOGI(TAG, "Mute:           %d", server_settings_message.muted);
-                    ESP_LOGI(TAG, "Setting volume: %d", server_settings_message.volume);
-                    muteCH[0] = server_settings_message.muted;
-                    muteCH[1] = server_settings_message.muted;
-                    muteCH[2] = server_settings_message.muted;
-                    muteCH[3] = server_settings_message.muted;
-                    if (server_settings_message.muted != client_state_muted )
-                    {
-                      client_state_muted = server_settings_message.muted;
-                      xQueueSend(flow_queue,&client_state_muted, 10);
-                    }
-                    // Volume setting using ADF HAL abstraction
-                    audio_hal_set_volume(board_handle->audio_hal,server_settings_message.volume);
-					break;
-
-                case SNAPCAST_MESSAGE_TIME:
-                    result = time_message_deserialize(&time_message, start, size);
-                    if (result) {
-                        ESP_LOGI(TAG, "Failed to deserialize time message\r\n");
-                        return;
-                    }
-                    // Calculate TClientDif : Trx-Tsend-Tnetdelay/2
-                    ttx.tv_sec  = base_message.sent.sec;
-                    ttx.tv_usec = base_message.sent.usec;
-                    trx.tv_sec  = base_message.received.sec;
-                    trx.tv_usec = base_message.received.usec;
-
-                    timersub(&trx,&ttx, &tdif);
-                    //ESP_LOGI(TAG, "Tclientdif :% 11ld.%03ld ", tdif.tv_sec ,  tdif.tv_usec/1000);
-
-
-                    //ESP_LOGI(TAG, "BaseTX  :% 11d.%03d ", base_message.sent.sec , base_message.sent.usec/1000);
-                    //ESP_LOGI(TAG, "BaseRX  :% 11d.%03d ", base_message.received.sec , base_message.received.usec/1000);
-                    //ESP_LOGI(TAG, "Latency :% 11d.%03d ", time_message.latency.sec,  time_message.latency.usec/1000);
-                    //ESP_LOGI(TAG, "Sub     :% 11d.%03d ", time_message.latency.sec + base_message.received.sec ,
-                    //                                      time_message.latency.usec/1000 + base_message.received.usec/1000);
-                    time_diff = time_message.latency.usec/1000 + base_message.received.usec/1000 -
-                               base_message.sent.usec/1000;
-                    time_diff = (time_diff > 1000) ? time_diff-1000 : time_diff ;
-                    //ESP_LOGI(TAG, "TM loopback latency: %03.1f ms", time_diff);
-                    break;
-            }
-            // If it's been a second or longer since our last time message was
-            // sent, do so now
-
-            result = gettimeofday(&now, NULL);
-            if (result) {
-                ESP_LOGI(TAG, "Failed to gettimeofday\r\n");
-                return;
-            }
-            timersub(&now, &last_time_sync, &tv1);
-
-            if (tv1.tv_sec >= 1) {
-                last_time_sync.tv_sec = now.tv_sec;
-                last_time_sync.tv_usec = now.tv_usec;
-
-                base_message.type = SNAPCAST_MESSAGE_TIME;
-                base_message.id = id_counter++;
-                base_message.refersTo = 0;
-                base_message.received.sec = 0;
-                base_message.received.usec = 0;
-                base_message.sent.sec = now.tv_sec;
-                base_message.sent.usec = now.tv_usec;
-                base_message.size = TIME_MESSAGE_SIZE;
-
-                result = base_message_serialize(
-                    &base_message,
-                    base_message_serialized,
-                    BASE_MESSAGE_SIZE
-                );
-                if (result) {
-                    ESP_LOGE(TAG, "Failed to serialize base message for time\r\n");
-                    continue;
-                }
-
-                result = time_message_serialize(&time_message, buff, SNAPCAST_BUFF_LEN);
-                if (result) {
-                    ESP_LOGI(TAG, "Failed to serialize time message\r\b");
-                    continue;
-                }
-                //ESP_LOGI(TAG, "---------------------------Write back time message \r\b");
-                write(sockfd, base_message_serialized, BASE_MESSAGE_SIZE);
-                write(sockfd, buff, TIME_MESSAGE_SIZE);
-            }
-        }
-        ESP_LOGI(TAG, "... done reading from socket\r\n");
-        close(sockfd);
+    // servaddr is configured, now open a connection
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+      ESP_LOGE(TAG, "... Failed to allocate socket.");
+      vTaskDelay(1000 / portTICK_PERIOD_MS);
+      continue;
     }
+    ESP_LOGI(TAG, "... allocated socket");
+
+    if (connect(sockfd, (struct sockaddr *)&servaddr, sizeof(servaddr)) != 0) {
+      ESP_LOGE(TAG, "... socket connect failed errno=%d", errno);
+      close(sockfd);
+      vTaskDelay(4000 / portTICK_PERIOD_MS);
+      continue;
+    }
+
+    ESP_LOGI(TAG, "... connected");
+
+    codec_header_message_t codec_header_message;
+    wire_chunk_message_t wire_chunk_message;
+    server_settings_message_t server_settings_message;
+
+    result = gettimeofday(&now, NULL);
+    if (result) {
+      ESP_LOGI(TAG, "Failed to gettimeofday\r\n");
+      return;
+    }
+
+    bool received_header = false;
+    base_message_t base_message = {
+        SNAPCAST_MESSAGE_HELLO,     // type
+        0x0,                        // id
+        0x0,                        // refersTo
+        {now.tv_sec, now.tv_usec},  // sent
+        {0x0, 0x0},                 // received
+        0x0,                        // size
+    };
+
+    hello_message_t hello_message = {
+        mac_address,
+        SNAPCAST_CLIENT_NAME,  // hostname
+        "0.0.2",               // client version
+        "libsnapcast",         // client name
+        "esp32",               // os name
+        "xtensa",              // arch
+        1,                     // instance
+        mac_address,           // id
+        2,                     // protocol version
+    };
+
+    hello_message_serialized =
+        hello_message_serialize(&hello_message, (size_t *)&(base_message.size));
+    if (!hello_message_serialized) {
+      ESP_LOGI(TAG, "Failed to serialize hello message\r\b");
+      return;
+    }
+
+    result = base_message_serialize(&base_message, base_message_serialized,
+                                    BASE_MESSAGE_SIZE);
+    if (result) {
+      ESP_LOGI(TAG, "Failed to serialize base message\r\n");
+      return;
+    }
+
+    write(sockfd, base_message_serialized, BASE_MESSAGE_SIZE);
+    write(sockfd, hello_message_serialized, base_message.size);
+    free(hello_message_serialized);
+
+    fd_set read_push_set;
+    // struct timeval to;
+    int retval;
+    for (;;) {
+      // Need to have time out if 100 ms between packeage to signal
+      size = 0;  // Audio flow stopped
+      // Read from socket with time out
+      FD_ZERO(&read_push_set);
+      FD_SET(sockfd, &read_push_set);
+
+      struct timeval to;
+      to.tv_sec = 0;
+      to.tv_usec = 300000;
+      // Block until input arrives on one or more active sockets.
+      retval = select(FD_SETSIZE, &read_push_set, NULL, NULL, &to);
+      if (retval) {
+        while (size < BASE_MESSAGE_SIZE) {
+          result = read(sockfd, &(buff[size]), BASE_MESSAGE_SIZE - size);
+          if (result < 0) {
+            ESP_LOGI(TAG, "Failed to read from server: %d\r\n", result);
+            return;
+          }
+          size += result;
+        }
+      } else {
+        ESP_LOGI(TAG, "Socket timeout after %d ms\r\n",
+                 (uint32_t)to.tv_usec / 1000);
+        client_state_muted = 2;
+        xQueueSend(flow_queue, &client_state_muted, 10);
+        continue;  // Return wait for next socket package
+      }
+
+      result = gettimeofday(&now, NULL);
+      if (result) {
+        ESP_LOGI(TAG, "Failed to gettimeofday\r\n");
+        return;
+      }
+
+      result = base_message_deserialize(&base_message, buff, size);
+      if (result) {
+        ESP_LOGI(TAG, "Failed to read base message: %d\r\n", result);
+        return;
+      }
+      // ESP_LOGI(TAG,"Rx dif : %d %d", base_message.sent.sec,
+      // base_message.sent.usec/1000);
+
+      base_message.received.sec = now.tv_sec;
+      base_message.received.usec = now.tv_usec;
+
+      start = buff;
+      size = 0;
+      while (size < base_message.size) {
+        result = read(sockfd, &(buff[size]), base_message.size - size);
+        if (result < 0) {
+          ESP_LOGI(TAG, "Failed to read from server: %d\r\n", result);
+          return;
+        }
+        size += result;
+      }
+
+      switch (base_message.type) {
+        case SNAPCAST_MESSAGE_CODEC_HEADER:
+          result = codec_header_message_deserialize(&codec_header_message,
+                                                    start, size);
+          if (result) {
+            ESP_LOGI(TAG, "Failed to read codec header: %d\r\n", result);
+            return;
+          }
+
+          ESP_LOGI(TAG, "Received codec header message\r\n");
+
+          size = codec_header_message.size;
+          start = codec_header_message.payload;
+          if (strcmp(codec_header_message.codec, "opus") == 0) {
+            uint32_t rate;
+            memcpy(&rate, start + 4, sizeof(rate));
+            uint16_t bits;
+            memcpy(&bits, start + 8, sizeof(bits));
+            memcpy(&channels, start + 10, sizeof(channels));
+            ESP_LOGI(TAG, "Opus sampleformat: %d:%d:%d\n", rate, bits,
+                     channels);
+            int error = 0;
+            decoder = opus_decoder_create(rate, channels, &error);
+            if (error != 0) {
+              ESP_LOGI(TAG, "Failed to init opus coder");
+              return;
+            }
+            codec = OPUS;
+            ESP_LOGI(TAG, "Initialized opus Decoder: %d", error);
+
+          } else if (strcmp(codec_header_message.codec, "pcm") == 0) {
+            codec = PCM;
+
+          } else {
+            ESP_LOGI(TAG, "Codec : %s not supported\n",
+                     codec_header_message.codec);
+            ESP_LOGI(TAG,
+                     "Change encoder codec to opus in /etc/snapserver.conf on "
+                     "server\n");
+            return;
+          }
+          ESP_LOGI(TAG, "Codec : %s , Size: %d \n", codec_header_message.codec,
+                   size);
+
+          codec_header_message_free(&codec_header_message);
+          received_header = true;
+
+          break;
+
+        case SNAPCAST_MESSAGE_WIRE_CHUNK:
+          cnt++;
+          if (!received_header) {  // Ignore audio packets until codec
+                                   // configured
+            continue;
+          }
+
+          result =
+              wire_chunk_message_deserialize(&wire_chunk_message, start, size);
+          if (result) {
+            ESP_LOGI(TAG, "Failed to read wire chunk: %d\r\n", result);
+            return;
+          }
+          size = wire_chunk_message.size;
+          start = (wire_chunk_message.payload);
+          switch (codec) {
+            case OPUS:
+              int frame_size = 0;
+              while ((frame_size = opus_decode(decoder, (unsigned char *)start,
+                                               size, (opus_int16 *)audio,
+                                               pcm_size / channels, 0)) ==
+                     OPUS_BUFFER_TOO_SMALL) {
+                pcm_size = pcm_size * 2;
+                ESP_LOGI(TAG,
+                         "OPUS encoding buffer too small, resizing to %d "
+                         "samples per channel",
+                         pcm_size / channels);
+              }
+              // ESP_LOGI(TAG, "time stamp in :
+              // %d",wire_chunk_message.timestamp.sec);
+              if (frame_size < 0) {
+                ESP_LOGE(TAG, "Decode error : %d \n", frame_size);
+              } else {
+                // pack(&timestampSize,wire_chunk_message.timestamp,frame_size*2*size(uint16_t))
+                memcpy(timestampSize, &wire_chunk_message.timestamp.sec,
+                       sizeof(wire_chunk_message.timestamp.sec));
+                memcpy(timestampSize + 4, &wire_chunk_message.timestamp.usec,
+                       sizeof(wire_chunk_message.timestamp.usec));
+                uint32_t chunk_size = frame_size * 2 * sizeof(uint16_t);
+                memcpy(timestampSize + 8, &chunk_size, sizeof(chunk_size));
+
+                // ESP_LOGI(TAG, "Network jitter %d %d",(uint32_t)
+                // wire_chunk_message.timestamp.usec/1000,
+                //                                          (uint32_t)
+                //                                          base_message.sent.usec/1000);
+
+                if ((chunk_res = write_ringbuf(timestampSize,
+                                               3 * sizeof(uint32_t))) != 12) {
+                  ESP_LOGI(TAG, "Error writing timestamp to ring buffer: %d",
+                           chunk_res);
+                }
+                if ((chunk_res = write_ringbuf((const uint8_t *)audio,
+                                               chunk_size)) != chunk_size) {
+                  ESP_LOGI(TAG, "Error writing data to ring buffer: %d",
+                           chunk_res);
+                }
+              }
+              break;
+
+            case PCM:
+              memcpy(timestampSize, &wire_chunk_message.timestamp.sec,
+                     sizeof(wire_chunk_message.timestamp.sec));
+              memcpy(timestampSize + 4, &wire_chunk_message.timestamp.usec,
+                     sizeof(wire_chunk_message.timestamp.usec));
+              uint32_t chunk_size = size;
+              memcpy(timestampSize + 8, &chunk_size, sizeof(chunk_size));
+
+              // ESP_LOGI(TAG, "Network jitter %d %d",(uint32_t)
+              // wire_chunk_message.timestamp.usec/1000,
+              //                                          (uint32_t)
+              //                                          base_message.sent.usec/1000);
+
+              if ((chunk_res = write_ringbuf(timestampSize,
+                                             3 * sizeof(uint32_t))) != 12) {
+                ESP_LOGI(TAG, "Error writing timestamp to ring buffer: %d",
+                         chunk_res);
+              }
+
+              if ((chunk_res = write_ringbuf((const uint8_t *)start, size)) !=
+                  size) {
+                ESP_LOGI(TAG, "Error writing data to ring buffer: %d",
+                         chunk_res);
+              }
+              break;
+          }
+          wire_chunk_message_free(&wire_chunk_message);
+          break;
+
+        case SNAPCAST_MESSAGE_SERVER_SETTINGS:
+          // The first 4 bytes in the buffer are the size of the string.
+          // We don't need this, so we'll shift the entire buffer over 4 bytes
+          // and use the extra room to add a null character so cJSON can pares
+          // it.
+          memmove(start, start + 4, size - 4);
+          start[size - 3] = '\0';
+          result = server_settings_message_deserialize(&server_settings_message,
+                                                       start);
+          if (result) {
+            ESP_LOGI(TAG, "Failed to read server settings: %d\r\n", result);
+            return;
+          }
+          // log mute state, buffer, latency
+          buffer_ms = server_settings_message.buffer_ms;
+          ESP_LOGI(TAG, "Buffer length:  %d",
+                   server_settings_message.buffer_ms);
+          ESP_LOGI(TAG, "Ringbuffer size:%d",
+                   server_settings_message.buffer_ms * 48 * 4);
+          ESP_LOGI(TAG, "Latency:        %d", server_settings_message.latency);
+          ESP_LOGI(TAG, "Mute:           %d", server_settings_message.muted);
+          ESP_LOGI(TAG, "Setting volume: %d", server_settings_message.volume);
+          muteCH[0] = server_settings_message.muted;
+          muteCH[1] = server_settings_message.muted;
+          muteCH[2] = server_settings_message.muted;
+          muteCH[3] = server_settings_message.muted;
+          if (server_settings_message.muted != client_state_muted) {
+            client_state_muted = server_settings_message.muted;
+            xQueueSend(flow_queue, &client_state_muted, 10);
+          }
+          // Volume setting using ADF HAL abstraction
+          audio_hal_set_volume(board_handle->audio_hal,
+                               server_settings_message.volume);
+          break;
+
+        case SNAPCAST_MESSAGE_TIME:
+          result = time_message_deserialize(&time_message, start, size);
+          if (result) {
+            ESP_LOGI(TAG, "Failed to deserialize time message\r\n");
+            return;
+          }
+          // Calculate TClientDif : Trx-Tsend-Tnetdelay/2
+          ttx.tv_sec = base_message.sent.sec;
+          ttx.tv_usec = base_message.sent.usec;
+          trx.tv_sec = base_message.received.sec;
+          trx.tv_usec = base_message.received.usec;
+
+          timersub(&trx, &ttx, &tdif);
+          // ESP_LOGI(TAG, "Tclientdif :% 11ld.%03ld ", tdif.tv_sec ,
+          // tdif.tv_usec/1000);
+
+          // ESP_LOGI(TAG, "BaseTX  :% 11d.%03d ", base_message.sent.sec ,
+          // base_message.sent.usec/1000); ESP_LOGI(TAG, "BaseRX  :% 11d.%03d ",
+          // base_message.received.sec , base_message.received.usec/1000);
+          // ESP_LOGI(TAG, "Latency :% 11d.%03d ", time_message.latency.sec,
+          // time_message.latency.usec/1000); ESP_LOGI(TAG, "Sub     :% 11d.%03d
+          // ", time_message.latency.sec + base_message.received.sec ,
+          //                                      time_message.latency.usec/1000
+          //                                      +
+          //                                      base_message.received.usec/1000);
+          time_diff = time_message.latency.usec / 1000 +
+                      base_message.received.usec / 1000 -
+                      base_message.sent.usec / 1000;
+          time_diff = (time_diff > 1000) ? time_diff - 1000 : time_diff;
+          // ESP_LOGI(TAG, "TM loopback latency: %03.1f ms", time_diff);
+          break;
+      }
+      // If it's been a second or longer since our last time message was
+      // sent, do so now
+
+      result = gettimeofday(&now, NULL);
+      if (result) {
+        ESP_LOGI(TAG, "Failed to gettimeofday\r\n");
+        return;
+      }
+      timersub(&now, &last_time_sync, &tv1);
+
+      if (tv1.tv_sec >= 1) {
+        last_time_sync.tv_sec = now.tv_sec;
+        last_time_sync.tv_usec = now.tv_usec;
+
+        base_message.type = SNAPCAST_MESSAGE_TIME;
+        base_message.id = id_counter++;
+        base_message.refersTo = 0;
+        base_message.received.sec = 0;
+        base_message.received.usec = 0;
+        base_message.sent.sec = now.tv_sec;
+        base_message.sent.usec = now.tv_usec;
+        base_message.size = TIME_MESSAGE_SIZE;
+
+        result = base_message_serialize(&base_message, base_message_serialized,
+                                        BASE_MESSAGE_SIZE);
+        if (result) {
+          ESP_LOGE(TAG, "Failed to serialize base message for time\r\n");
+          continue;
+        }
+
+        result = time_message_serialize(&time_message, buff, SNAPCAST_BUFF_LEN);
+        if (result) {
+          ESP_LOGI(TAG, "Failed to serialize time message\r\b");
+          continue;
+        }
+        // ESP_LOGI(TAG, "---------------------------Write back time message
+        // \r\b");
+        write(sockfd, base_message_serialized, BASE_MESSAGE_SIZE);
+        write(sockfd, buff, TIME_MESSAGE_SIZE);
+      }
+    }
+    ESP_LOGI(TAG, "... done reading from socket\r\n");
+    close(sockfd);
+  }
 }
 
+void app_main(void) {
+  esp_err_t ret = nvs_flash_init();
+  if (ret == ESP_ERR_NVS_NO_FREE_PAGES ||
+      ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    ret = nvs_flash_init();
+  }
+  ESP_ERROR_CHECK(ret);
 
-void app_main(void)
-{
-    esp_err_t ret = nvs_flash_init();
-    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-      ESP_ERROR_CHECK(nvs_flash_erase());
-      ret = nvs_flash_init();
-    }
-    ESP_ERROR_CHECK(ret);
+  ESP_LOGI(TAG, "Start codec chip");
+  board_handle = audio_board_init();
+  audio_hal_ctrl_codec(board_handle->audio_hal, AUDIO_HAL_CODEC_MODE_BOTH,
+                       AUDIO_HAL_CTRL_START);
+  i2s_mclk_gpio_select(0, 0);
 
-	ESP_LOGI(TAG, "Start codec chip");
-    board_handle = audio_board_init();
-    audio_hal_ctrl_codec(
-		board_handle->audio_hal, AUDIO_HAL_CODEC_MODE_BOTH, AUDIO_HAL_CTRL_START);
-    i2s_mclk_gpio_select(0, 0);
+  dsp_setup_flow(500, 48000);
 
-    dsp_setup_flow(500, 48000);
-
-    // Enable and setup WIFI in station mode  and connect to Access point setup in menu config
-    wifi_init_sta();
-    net_mdns_register("snapclient");
+  // Enable and setup WIFI in station mode  and connect to Access point setup in
+  // menu config
+  wifi_init_sta();
+  net_mdns_register("snapclient");
 #ifdef CONFIG_SNAPCLIENT_SNTP_ENABLE
-    set_time_from_sntp();
+  set_time_from_sntp();
 #endif
-    flow_queue = xQueueCreate( 10 , sizeof(uint32_t));
-    xTaskCreate(&ota_server_task, "ota_server_task", 4096, NULL, 15, NULL);
+  flow_queue = xQueueCreate(10, sizeof(uint32_t));
+  xTaskCreate(&ota_server_task, "ota_server_task", 4096, NULL, 15, NULL);
 
-    xTaskCreatePinnedToCore(&http_get_task, "http_get_task", 3*4096, NULL, 5, &t_http_get_task, 1);
-    while (1) {
-        //audio_event_iface_msg_t msg;
-        vTaskDelay(1000/portTICK_PERIOD_MS);
-        //ma120_read_error(0x20);
+  xTaskCreatePinnedToCore(&http_get_task, "http_get_task", 3 * 4096, NULL, 5,
+                          &t_http_get_task, 1);
+  while (1) {
+    // audio_event_iface_msg_t msg;
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    // ma120_read_error(0x20);
 
-        //int res = ma_read(0x20,2,0x011a, rxbuf,3);
-        //ESP_LOGI(TAG,"Error : 0x%02x 0x%02x 0x%02x\n",rxbuf[0], rxbuf[1], rxbuf[2] );
+    // int res = ma_read(0x20,2,0x011a, rxbuf,3);
+    // ESP_LOGI(TAG,"Error : 0x%02x 0x%02x 0x%02x\n",rxbuf[0], rxbuf[1],
+    // rxbuf[2] );
 
-        esp_err_t ret = 0; //audio_event_iface_listen(evt, &msg, portMAX_DELAY);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "[ * ] Event interface error : %d", ret);
-            continue;
-        }
-
-       }
+    esp_err_t ret = 0;  // audio_event_iface_listen(evt, &msg, portMAX_DELAY);
+    if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "[ * ] Event interface error : %d", ret);
+      continue;
+    }
+  }
 }

--- a/snapcast/snapserver.conf
+++ b/snapcast/snapserver.conf
@@ -32,7 +32,7 @@
 #port = 1780
 
 # serve a website from the doc_root location
-#doc_root = 
+#doc_root =
 #
 ###############################################################################
 
@@ -70,7 +70,7 @@
 #port = 1704
 
 # stream URI of the PCM input stream, can be configured multiple times
-# Format: TYPE://host/path?name=NAME[&codec=CODEC][&sampleformat=SAMPLEFORMAT] 
+# Format: TYPE://host/path?name=NAME[&codec=CODEC][&sampleformat=SAMPLEFORMAT]
 stream = pipe:///tmp/snapfifo?name=default
 
 # Default sample format
@@ -102,6 +102,6 @@ buffer = 1000
 #debug = false
 
 # log file name for the debug logs (debug must be enabled)
-#debug_logfile = 
+#debug_logfile =
 #
 ###############################################################################


### PR DESCRIPTION
Here is the result after having applied checkers suggested in the pre-commit hoos in #19 (clang-format, trailing ws, codespell) 

Acctually depends on #19